### PR TITLE
Allow "globbing" filenames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test/fixtures/*/myapp/
 *.gem
 
 .DS_Store
+Gemfile.lock

--- a/lib/rundoc/code_command/file_command/append.rb
+++ b/lib/rundoc/code_command/file_command/append.rb
@@ -1,5 +1,6 @@
 class Rundoc::CodeCommand::FileCommand
   class Append < Rundoc::CodeCommand
+    include FileUtil
 
     def initialize(filename)
       @filename, line = filename.split('#')
@@ -14,9 +15,9 @@ class Rundoc::CodeCommand::FileCommand
       raise "must call write in its own code section" unless env[:commands].empty?
       before = env[:before]
       if @line_number
-        env[:before] = "In file `#{@filename}`, on line #{@line_number} add:\n\n#{before}"
+        env[:before] = "In file `#{filename}`, on line #{@line_number} add:\n\n#{before}"
       else
-        env[:before] = "At the end of `#{@filename}` add:\n\n#{before}"
+        env[:before] = "At the end of `#{filename}` add:\n\n#{before}"
       end
       nil
     end
@@ -40,7 +41,7 @@ class Rundoc::CodeCommand::FileCommand
 
     def insert_contents_into_at_line(doc)
       lines = doc.lines
-      raise "Expected #{@filename} to have at least #{@line_number} but only has #{lines.count}" if lines.count < @line_number
+      raise "Expected #{filename} to have at least #{@line_number} but only has #{lines.count}" if lines.count < @line_number
       result = []
       lines.each_with_index do |line, index|
         line_number = index.next
@@ -54,19 +55,17 @@ class Rundoc::CodeCommand::FileCommand
     end
 
     def call(env = {})
-      dir = File.expand_path("../", @filename)
-      FileUtils.mkdir_p(dir)
-
-      doc = File.read(@filename)
+      mkdir_p
+      doc = File.read(filename)
       if @line_number
-        puts "Writing to: '#{@filename}' line #{@line_number} with: #{contents.inspect}"
+        puts "Writing to: '#{filename}' line #{@line_number} with: #{contents.inspect}"
         doc = insert_contents_into_at_line(doc)
       else
-        puts "Appending to file: '#{@filename}' with: #{contents.inspect}"
+        puts "Appending to file: '#{filename}' with: #{contents.inspect}"
         doc = concat_with_newline(doc, contents)
       end
 
-      File.open(@filename, "w") do |f|
+      File.open(filename, "w") do |f|
         f.write(doc)
       end
       contents

--- a/lib/rundoc/code_command/file_command/remove.rb
+++ b/lib/rundoc/code_command/file_command/remove.rb
@@ -1,5 +1,6 @@
 class Rundoc::CodeCommand::FileCommand
   class Remove < Rundoc::CodeCommand
+    include FileUtil
 
     def initialize(filename)
       @filename = filename
@@ -8,19 +9,19 @@ class Rundoc::CodeCommand::FileCommand
     def to_md(env)
       raise "must call write in its own code section" unless env[:commands].empty?
       before = env[:before]
-      env[:before] = "In file `#{@filename}` remove:\n\n#{before}"
+      env[:before] = "In file `#{filename}` remove:\n\n#{before}"
       nil
     end
 
     def call(env = {})
-      puts "Deleting '#{contents.strip}' from #{@filename}"
-      raise "#{@filename} does not exist" unless File.exist?(@filename)
+      puts "Deleting '#{contents.strip}' from #{filename}"
+      raise "#{filename} does not exist" unless File.exist?(filename)
 
       regex = /^\s*#{Regexp.quote(contents)}/
-      doc   = File.read(@filename)
+      doc   = File.read(filename)
       doc.sub!(regex, '')
 
-      File.open(@filename, "w") do |f|
+      File.open(filename, "w") do |f|
         f.write(doc)
       end
       contents

--- a/lib/rundoc/code_command/write.rb
+++ b/lib/rundoc/code_command/write.rb
@@ -1,6 +1,23 @@
 module Rundoc
   class CodeCommand
+    module FileUtil
+      def filename
+        files = Dir.glob(@filename)
+        if files.length > 1
+          raise "Filename glob #{@filename.inspect} matched more than one file. Be more specific to only match one file. Matches:\n" + files.join("  \n")
+        end
+        files.first || @filename
+      end
+
+      def mkdir_p
+        dir = File.expand_path("../", filename)
+        FileUtils.mkdir_p(dir)
+      end
+    end
+
     class Write < Rundoc::CodeCommand
+      include FileUtil
+
       def initialize(filename)
         @filename = filename
       end
@@ -8,16 +25,14 @@ module Rundoc
       def to_md(env)
         raise "must call write in its own code section" unless env[:commands].empty?
         before = env[:before]
-        env[:before] = "In file `#{@filename}` write:\n\n#{before}"
+        env[:before] = "In file `#{filename}` write:\n\n#{before}"
         nil
       end
 
       def call(env = {})
-        puts "Writing to: '#{@filename}'"
-
-        dir = File.expand_path("../", @filename)
-        FileUtils.mkdir_p(dir)
-        File.open(@filename, "w") do |f|
+        puts "Writing to: '#{filename}'"
+        mkdir_p
+        File.open(filename, "w") do |f|
           f.write(contents)
         end
         contents

--- a/test/rundoc/code_commands/append_file_test.rb
+++ b/test/rundoc/code_commands/append_file_test.rb
@@ -52,4 +52,31 @@ gem 'rails', '4.0.0'
     end
   end
 
+  def test_globs_filenames
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        filename = "file-#{Time.now.utc.strftime("%Y%m%d%H%M%S")}.txt"
+        FileUtils.touch(filename)
+        cc = Rundoc::CodeCommand::FileCommand::Append.new("file-*.txt")
+        cc << "some text"
+        cc.call
+
+        assert_equal "\nsome text\n", File.read(filename)
+      end
+    end
+  end
+
+  def test_glob_multiple_matches_raises
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        FileUtils.touch("file-1234.txt")
+        FileUtils.touch("file-5678.txt")
+        assert_raise do
+          cc = Rundoc::CodeCommand::FileCommand::Append.new("file-*.txt")
+          cc << "some text"
+          cc.call
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is useful for a case where the filename is not known, such as when
a migration is generated in Rails and we want to write into the
migration file. We can replace the migration number with "*" to glob the
filename to append/write/remove.

If there are more than one file matching the glob, an error is raised.