### PR TITLE
Update syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,11 @@ All runDOC commands are prefixed with three colons `:::` and are inclosed in a c
 command such as `$` which is an alias for `bash` commands like this:
 
     ```
-    ::: $ git init .
+    :::> $ git init .
     ```
 
 Nothing before the three colons matters. The space between the colons
 and the command is optional.
-
 
 If you don't want the command to output to your markdown document you
 can add a minus symbol `-` to the end to prevent it from being
@@ -84,13 +83,13 @@ rendered.
     :::- $ git init .
     ```
 
-Note: If all commands inside of a code block are hidden, the entire codeblock will not be rendered.
+> Note: If all commands inside of a code block are hidden, the entire codeblock will not be rendered.
 
 If you want the output of the actual command to be rendered to
-the screen you can use an equal sign so that
+the screen you can use two arrows so that:
 
     ```
-    :::= $ ls
+    :::>> $ ls
     ```
 
 This code block might generate an output something like this to your markdown doc:
@@ -103,6 +102,16 @@ This code block might generate an output something like this to your markdown do
 
 That's the syntax, let's look at different runDOC commands
 
+## Rendering Cheat Sheet
+
+An arrow `>` is shorthand for "render this" and a dash `-` is shorthand for skip this section. The posions two positions are command first and result second. You can skip a trailing `-`.
+
+
+- `:::>`  (yes command, not result)
+- `:::>>` (yes command, yes result)
+- `:::-`  (not command, not result)
+- `:::->` (not command, yes result)
+
 ## Shell Commands
 
 Current Commands:
@@ -113,7 +122,7 @@ Current Commands:
 Anything you pass to `$` will be run in a shell. Any items below the command will be passed into the stdin of the bash command so:
 
     ```
-    :::= $ tail -n 2
+    :::>> $ tail -n 2
     foo
     bar
     baz
@@ -128,12 +137,12 @@ Would output:
    bahz
    ```
 
-This could be useful if you are running an interactive command such as `play new` which requires user input. For more fine grained input you'll need to use a custom repl object (will be covered later).
+This STDIN feature could be useful if you are running an interactive command such as `play new` which requires user input. For more fine grained input you'll need to use a custom repl object (will be covered later).
 
 If a shell command returns a non-zero exit status an error will be raised, if you expect a command to fail you can run it with `fail.$` keyword
 
     ```
-    :::= fail.$ cat /dev/null/foo
+    :::>> fail.$ cat /dev/null/foo
     ```
 
 Even though this command returns a non zero exit status, the contents of the command will be written since we're stating that we don't care if the command fails. This would be the output:
@@ -148,14 +157,14 @@ Some commands may be custom, for example when running `cd` you likely want to ch
 
 
     ```
-    :::= $ cd myapp/config
-    :::= $ cat database.yml
+    :::>> $ cd myapp/config
+    :::>> $ cat database.yml
     ```
 
-However this command would fall on it's face:
+However this command would fall on its face:
 
     ```
-    :::= $ cd myapp/config && cat database.yml
+    :::>> $ cd myapp/config && cat database.yml
     ```
 
 These custom commands are kept to a minimum, and for the most part behave as you would expect them to. Write your docs as you normally would and check the output frequently.
@@ -170,10 +179,10 @@ Current Commands:
 - `file.append`
 - `file.remove`
 
-Use the `filewrite` keyword followed by a filename, on the next line(s) put the contents of the file
+Use the `file.write` keyword followed by a filename, on the next line(s) put the contents of the file
 
     ```
-    ::: file.write config/routes.rb
+    :::> file.write config/routes.rb
 
     Example::Application.routes.draw do
       root        :to => "pages#index"
@@ -187,7 +196,7 @@ Use the `filewrite` keyword followed by a filename, on the next line(s) put the 
 If you wanted to change `users` to `products` you could write to the same file again.
 
     ```
-    ::: file.write config/routes.rb
+    :::> file.write config/routes.rb
     Example::Application.routes.draw do
       root        :to => "pages#index"
 
@@ -202,7 +211,7 @@ To fully delete files use bash `$` command such as `::: $ rm foo.rb`.
 To add contents to a file you can use `file.append`
 
     ```
-    :::= file.append myapp/Gemfile
+    :::>> file.append myapp/Gemfile
     gem 'pg'
     gem 'sextant', group: :development
     gem 'wicked'
@@ -212,7 +221,7 @@ To add contents to a file you can use `file.append`
 The contents of the file (in this example a file named `Gemfile`) will remain unchanged, but the contents of the `file.append` block will now appear in the bottom of the file. If you want to append the contents to a specific part of the file instead of the end of the file you can specify line number by putting a hash (`#`) then a number following it.
 
     ```
-    :::= file.append myapp/Gemfile#22
+    :::>> file.append myapp/Gemfile#22
     gem 'rails_12factor'
     ```
 This will add the `gem 'rails_12factor'` on line 22 of the file `myapp/Gemfile`. If line 22 has existing contents, they will be bumped down to line 23.
@@ -220,7 +229,7 @@ This will add the `gem 'rails_12factor'` on line 22 of the file `myapp/Gemfile`.
 Some times you may want to remove a small amount of text from an existing file. You can do this using `file.remove`, you pass in the contents you want removed:
 
     ```
-    :::= file.remove myapp/Gemfile
+    :::>> file.remove myapp/Gemfile
     gem 'sqlite3'
     ```
 
@@ -228,20 +237,19 @@ When this is run, the file `Gemfile` will be modified to not include `gem 'sqlit
 
 Note: `file.remove` currently requires a very explicit match so things like double versus single quotes, whitespace, and letter case all matter. Current best practice is to only use it for single line removals.
 
-
 ## Pipe
 
 Commands:
 - `|`
 - `pipe` (aliased `|`)
 
-Sometimes you need to need to pass data from one command to another. To do this there is a provided pipe command `|`
+Sometimes you need to need to pass data from one command to another. To do this there is a provided pipe command `|`.
 
 Let's say you want to output the first 23 lines of a file but you don't want to confuse your users with an additional pipe command in your shell line you could write something like this:
 
 ```sh
-:::  $ cat config/database.yml
-:::= | $ head -n 23
+:::>  $ cat config/database.yml
+:::>> | $ head -n 23
 ```
 
 Anything after the pipe `|` will generate a new command with the output of the previous command passed to it. The pipe command will only ouput its result, so the user will not know it was even executed.
@@ -306,10 +314,27 @@ This command `filter_sensitive` can be called multiple times with different valu
 
 This is a section for brainstorming. If it's here it's not guaranteed to get worked on, but it will be considered.
 
-- Breakpoints?
-- Better line matching for backtrace
-- `-=` command (runs command, only shows output, does not show command)
+- Seperate parsing from running. This will help for easier linting of syntax etc.
+- Cache SHAs and output of each code block. If one sha changes, re-generate all code blocks, otherwise allow a re-render without code execution. Configure a check sum for busting the cache for instance a new version of Rails is released.
+
+
 - A way to run background processes indefinitely such as `rails server`
+  - Maybe a way to truncate them after only a period of time such as grab a few lines of `heroku local`.
+
+
+    ```
+    :::> background.start(command: "rails server")
+    ```
+
+    ```
+    :::>> background.read("rails server")
+    :::> | $ head -n 23
+    :::> background.clear
+    ```
+
+
+  - Breakpoints?
+- Better line matching for backtrace
+- `-=` command (runs command, only shows output, does not show command) ?
 - An easy test syntax?
 - Screenshot tool(s) ?!?!?!?!?!?! :)
-

--- a/lib/rundoc/code_command.rb
+++ b/lib/rundoc/code_command.rb
@@ -1,10 +1,14 @@
 module Rundoc
   class CodeCommand
-    attr_accessor :hidden, :render_result, :command, :contents, :keyword
-    alias :hidden? :hidden
+    attr_accessor :render_result, :render_command, :command, :contents, :keyword
     alias :render_result? :render_result
+    alias :render_command? :render_command
 
     def initialize(arg)
+    end
+
+    def hidden?
+      !render_command? && !render_result?
     end
 
     def not_hidden?

--- a/lib/rundoc/parser.rb
+++ b/lib/rundoc/parser.rb
@@ -5,7 +5,7 @@ module Rundoc
     GITHUB_BLOCK       = '^(?<fence>(?<fence_char>~|`){3,})\s*?(?<lang>\w+)?\s*?\n(?<contents>.*?)^\g<fence>\g<fence_char>*\s*?\n'
     CODEBLOCK_REGEX    = /(#{GITHUB_BLOCK})/m
     COMMAND_REGEX      = ->(keyword) {
-                             /^#{keyword}(?<tag>(\s|=|-)?)\s*(?<command>(\S)+)\s+(?<statement>.*)$/
+                             /^#{keyword}(?<tag>(\s|=|-|>)?(=|-|>)?)\s*(?<command>(\S)+)\s+(?<statement>.*)$/
                             }
 
     attr_reader :contents, :keyword, :stack

--- a/rundoc.gemspec
+++ b/rundoc.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "thor"
   gem.add_dependency "repl_runner"
 
-  gem.add_development_dependency "test-unit"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "test-unit"

--- a/test/fixtures/rails_5/rundoc.md
+++ b/test/fixtures/rails_5/rundoc.md
@@ -54,19 +54,19 @@ Press enter at the prompt to upload your existing `ssh` key or create a new one,
 If you are starting from an existing app, [upgrade to Rails 5](http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-4-2-to-rails-5-0) before continuing. If not, a vanilla Rails 5 app will serve as a suitable sample app. To build a new app make sure that you're using the Rails 5.x using `$ rails -v`. You can get the new version of rails by running,
 
 ```term
-:::= $ gem install rails --no-ri --no-rdoc
+:::>> $ gem install rails --no-ri --no-rdoc
 ```
 
 Then create a new app:
 
 ```term
-::: $ rails new myapp --database=postgresql
+:::> $ rails new myapp --database=postgresql
 ```
 
 Then move into your application directory.
 
 ```term
-::: $ cd myapp
+:::> $ cd myapp
 ```
 
 > callout If you experience problems or get stuck with this tutorial, your questions may be answered in a later part of this document. If you experience a problem, try reading through the entire document and then go back to your issue. It can also be useful to review your previous steps to ensure they all executed correctly.
@@ -100,7 +100,7 @@ In addition to using the `pg` gem, you'll also need to ensure the `config/databa
 The development section of your `config/database.yml` file should look something like this:
 
 ```term
-:::=  $ cat config/database.yml
+:::>  $ cat config/database.yml
 ```
 
 Be careful here. If you omit the `sql` at the end of `postgresql` in the `adapter` section, your application will not work.
@@ -110,13 +110,13 @@ Be careful here. If you omit the `sql` at the end of `postgresql` in the `adapte
 Rails 5 no longer has a static index page in production. When you're using a new app, there will not be a root page in production, so we need to create one. We will first create a controller called `welcome` for our home page to live:
 
 ```term
-::: $ rails generate controller welcome
+:::> $ rails generate controller welcome
 ```
 
 Next we'll add an index page.
 
 ```html
-:::= file.write app/views/welcome/index.html.erb
+:::>> file.write app/views/welcome/index.html.erb
 <h2>Hello World</h2>
 <p>
   The time is now: <%= Time.now %>
@@ -126,7 +126,7 @@ Next we'll add an index page.
 Now we need to make Rails route to this action. We'll edit `config/routes.rb` to set the index page to our new method:
 
 ```ruby
-:::= file.append config/routes.rb#2
+:::>> file.append config/routes.rb#2
   root 'welcome#index'
 ```
 
@@ -158,7 +158,7 @@ end
 Rails 5 requires Ruby 2.2.0 or above. Heroku has a recent version of Ruby installed by default, however you can specify an exact version by using the `ruby` DSL in your `Gemfile`.
 
 ```ruby
-:::= file.append Gemfile
+:::>> file.append Gemfile
 ruby "2.4.1"
 ```
 
@@ -169,8 +169,8 @@ You should also be running the same version of Ruby locally. You can check this 
 Heroku relies on [Git](http://git-scm.com/), a distributed source control management tool, for deploying your project. If your project is not already in Git, first verify that `git` is on your system:
 
 ```term
-::: $ git --help
-:::= | $ head -n 5
+:::>  $ git --help
+:::>> | $ head -n 5
 ```
 
 If you don't see any output or get `command not found` you will need to install it on your system. Verify that the [Heroku toolbelt](https://toolbelt.heroku.com/) is installed.
@@ -180,21 +180,21 @@ Once you've verified that Git works, first make sure you are in your Rails app d
 The output should look like this:
 
 ```term
-:::= $ ls
+:::>> $ ls
 ```
 
 Now run these commands in your Rails app directory to initialize and commit your code to Git:
 
 ```term
-::: $ git init
-::: $ git add .
-::: $ git commit -m "init"
+:::> $ git init
+:::> $ git add .
+:::> $ git commit -m "init"
 ```
 
 You can verify everything was committed correctly by running:
 
 ```term
-:::= $ git status
+:::>> $ git status
 ```
 
 Now that your application is committed to Git you can deploy to Heroku.
@@ -204,13 +204,13 @@ Now that your application is committed to Git you can deploy to Heroku.
 Make sure you are in the directory that contains your Rails app, then create an app on Heroku:
 
 ```term
-:::= $ heroku create
+:::>> $ heroku create
 ```
 
 You can verify that the remote was added to your project by running:
 
 ```term
-:::= $ git config --list | grep heroku
+:::>> $ git config --list | grep heroku
 ```
 
 If you see `fatal: not in a git directory` then you are likely not in the correct directory. Otherwise you may deploy your code. After you deploy your code, you will need to migrate your database, make sure it is properly scaled, and use logs to debug any issues that come up.
@@ -218,7 +218,7 @@ If you see `fatal: not in a git directory` then you are likely not in the correc
 Deploy your code:
 
 ```term
-:::= $ git push heroku master
+:::>> $ git push heroku master
 ```
 
 It is always a good idea to check to see if there are any warnings or errors in the output. If everything went well you can migrate your database.
@@ -240,13 +240,13 @@ You've deployed your code to Heroku. You can now instruct Heroku to execute a pr
 Let's ensure we have one dyno running the `web` process type:
 
 ```term
-::: $ heroku ps:scale web=1
+:::> $ heroku ps:scale web=1
 ```
 
 You can check the state of the app's dynos. The `heroku ps` command lists the running dynos of your application:
 
 ```term
-:::= $ heroku ps
+:::>> $ heroku ps
 ```
 
 Here, one dyno is running.
@@ -254,7 +254,7 @@ Here, one dyno is running.
 We can now visit the app in our browser with `heroku open`.
 
 ```term
-:::= $ heroku open
+:::>> $ heroku open
 ```
 
 You should now see the "Hello World" text we inserted above.
@@ -268,7 +268,7 @@ If you run into any problems getting your app to perform properly, you will need
 You can view information about your running app using one of the [logging commands](logging), `heroku logs`:
 
 ```term
-:::= $ heroku logs
+:::>> $ heroku logs
 ```
 
 You can also get the full stream of logs by running the logs command with the `--tail` flag option like this:
@@ -314,10 +314,10 @@ gem 'puma'
 Then run
 
 ```term
-::: $ bundle install
+:::> $ bundle install
 ```
 
-Now you are ready to configure your app to use Puma. For this tutorial we will use the default settings of Puma, but we recommend generating a `config/puma.rb` file and reading more about configuring your application for maximum performance by [reading the Puma documentation](https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server)
+Now you are ready to configure your app to use Puma. For this tutorial we will use the default `config/puma.rb` of that ships with Rails 5, but we recommend reading more about configuring your application for maximum performance by [reading the Puma documentation](https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server).
 
 Finally you will need to tell Heroku how to run your Rails app by creating a `Procfile` in the root of your application directory.
 
@@ -326,11 +326,11 @@ Finally you will need to tell Heroku how to run your Rails app by creating a `Pr
 Change the command used to launch your web process by creating a file called [Procfile](procfile) and entering this:
 
 ```
-:::= file.write Procfile
+:::>> file.write Procfile
 web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
 ```
 
-Note: The case of `Procfile` matters, the first letter must be uppercase.
+> Note: The case of `Procfile` matters, the first letter must be uppercase.
 
 We recommend generating a Puma config file based on [our Puma documentation](https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server) for maximum performance.
 
@@ -339,8 +339,8 @@ To use the Procfile locally you can use `heroku local`.
 In addition to running commands in your `Procfile` `heroku local` can also help you manage environment variables locally through a `.env` file. Set the local `RACK_ENV` to development in your environment and a `PORT` to connect to. Before pushing to Heroku you'll want to test with the `RACK_ENV` set to production since this is the environment your Heroku app will run in.
 
 ```term
-:::= $ echo "RACK_ENV=development" >>.env
-:::= $ echo "PORT=3000" >> .env
+:::>> $ echo "RACK_ENV=development" >>.env
+:::>> $ echo "PORT=3000" >> .env
 ```
 
 > Note: Another alternative to using environment variables locally with a `.env` file is the [dotenv](https://github.com/bkeepers/dotenv) gem.
@@ -348,15 +348,15 @@ In addition to running commands in your `Procfile` `heroku local` can also help 
 You'll also want to add `.env` to your `.gitignore` since this is for local environment setup.
 
 ```term
-::: $ echo ".env" >> .gitignore
-::: $ git add .gitignore
-::: $ git commit -m "add .env to .gitignore"
+:::> $ echo ".env" >> .gitignore
+:::> $ git add .gitignore
+:::> $ git commit -m "add .env to .gitignore"
 ```
 
 Test your Procfile locally using Foreman. You can now start your web server by running:
 
 ```term
-$  heroku local
+$ heroku local
 [OKAY] Loaded ENV .env File as KEY=VALUE Format
 11:06:35 AM web.1   |  [18878] Puma starting in cluster mode...
 11:06:35 AM web.1   |  [18878] * Version 3.8.2 (ruby 2.4.1-p111), codename: Sassy Salamander
@@ -369,15 +369,15 @@ $  heroku local
 Looks good, so press `Ctrl+C` to exit and you can deploy your changes to Heroku:
 
 ```term
-::: $ git add .
-::: $ git commit -m "use puma via procfile"
-::: $ git push heroku master
+:::> $ git add .
+:::> $ git commit -m "use puma via procfile"
+:::> $ git push heroku master
 ```
 
 Check `ps`. You'll see that the web process uses your new command specifying Puma as the web server.
 
 ```term
-:::= $ heroku ps
+:::>> $ heroku ps
 ```
 
 The logs also reflect that we are now using Puma.

--- a/test/rundoc/parser_test.rb
+++ b/test/rundoc/parser_test.rb
@@ -10,8 +10,8 @@ class ParserTest < Test::Unit::TestCase
 sup
 
 ```
-:::  $ mkdir foo
-:::= $ ls
+:::>  $ mkdir foo
+:::>> $ ls
 ```
 
 yo
@@ -39,7 +39,7 @@ RUBY
 sup
 
 ```
-:::= write foo/code.rb
+:::>> write foo/code.rb
 a = 1 + 1
 b = a * 2
 ```
@@ -60,9 +60,9 @@ RUBY
     contents =  <<-RUBY
 
 ```
-:::= write foo/newb.rb
+:::>> write foo/newb.rb
 puts 'hello world'
-:::= $ cat foo/newb.rb
+:::>> $ cat foo/newb.rb
 ```
 RUBY
 
@@ -81,7 +81,7 @@ RUBY
 
     contents =  <<-RUBY
 ```
-:::= irb --simple-prompt
+:::>> irb --simple-prompt
 a = 3
 b = "foo" * a
 puts b

--- a/test/rundoc/regex_test.rb
+++ b/test/rundoc/regex_test.rb
@@ -100,13 +100,13 @@ RUBY
 foo
 
 ```
-:::$ mkdir
+:::>$ mkdir
 ```
 
 zoo
 
 ```
-:::$ cd ..
+:::>$ cd ..
 something
 ```
 
@@ -117,8 +117,8 @@ RUBY
 
     actual   = contents.partition(regex)
     expected = ["foo\n\n",
-                "```\n:::$ mkdir\n```\n",
-                "\nzoo\n\n```\n:::$ cd ..\nsomething\n```\n\nbar\n"]
+                "```\n:::>$ mkdir\n```\n",
+                "\nzoo\n\n```\n:::>$ cd ..\nsomething\n```\n\nbar\n"]
 
     assert_equal  expected, actual
 
@@ -137,7 +137,7 @@ RUBY
 
     contents =  <<-RUBY
 ```java
-:::= write app/controllers/Application.java
+:::>> write app/controllers/Application.java
 package controllers;
 
 import static java.util.concurrent.TimeUnit.SECONDS;


### PR DESCRIPTION
The previous output directives (i.e. `:::=`) were similar to ERB, but did not allow a way to render only the result and not the command. To allow for this syntax I've adopted the use of the characters `>` (arrow) and `-` (dash).

These indicate, render (`>`) and do-not render (`-`) respectively. Their positions correspond to code command and result so `:::->` indicates you do not want to command to render, but do want the result.

Here are our four different cases:


- `:::>`  (yes command, not result)
- `:::>>` (yes command, yes result)
- `:::-`  (not command, not result)
- `:::->` (not command, yes result)