### PR TITLE
Allow non-headless browser sessions and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ This will generate a project folder with your project in it, and a markdown READ
   - [background.log.clear](#background)
 - Take screenshots
   - [website.visit](#screenshots)
+  - [website.nav](#screenshots)
   - [website.screenshot](#screenshots)
 - Configure Rundoc
   - [rundoc](#configure)
@@ -384,12 +385,24 @@ Once you're on the page you want to capture you can execute `website.screenshot`
 ```
 :::>> website.visit(name: "localhost", url: "http://localhost:3000", scroll: 100)
 session.execute_script "window.scrollBy(0,100)"
-session.click("sign up")
+session.first(:link, "sign up").click
 
 :::>> website.screenshot(name: "localhost")
 ```
 
 The result of the screenshot command will be to replace the code section with a markdown link to a relative path of the screenshot.
+
+Once you've visited a website you can further navigate using `website.nav` or `website.navigate`:
+
+
+```
+:::>> website.visit(name: "localhost", url: "http://localhost:3000")
+:::>> website.navigate(name: "localhost")
+session.execute_script "window.scrollBy(0,100)"
+session.first(:link, "sign up").click
+
+:::>> website.screenshot(name: "localhost")
+```
 
 ## Upload Screenshots
 

--- a/lib/rundoc/code_command/website.rb
+++ b/lib/rundoc/code_command/website.rb
@@ -4,3 +4,4 @@ end
 require 'rundoc/code_command/website/driver'
 require 'rundoc/code_command/website/screenshot'
 require 'rundoc/code_command/website/visit'
+require 'rundoc/code_command/website/navigate'

--- a/lib/rundoc/code_command/website/navigate.rb
+++ b/lib/rundoc/code_command/website/navigate.rb
@@ -1,0 +1,29 @@
+class Rundoc::CodeCommand::Website
+  class Navigate < Rundoc::CodeCommand
+    def initialize(name: )
+      @name   = name
+      @driver = Rundoc::CodeCommand::Website::Driver.find(name)
+    end
+
+    def to_md(env = {})
+      ""
+    end
+
+    def call(env = {})
+      puts "website.navigate [#{@name}]: #{contents}"
+      @driver.safe_eval(contents)
+      ""
+    end
+
+    def hidden?
+      true
+    end
+
+    def not_hidden?
+      !hidden?
+    end
+  end
+end
+
+Rundoc.register_code_command(:"website.nav", Rundoc::CodeCommand::Website::Navigate)
+Rundoc.register_code_command(:"website.navigate", Rundoc::CodeCommand::Website::Navigate)

--- a/lib/rundoc/code_command/website/visit.rb
+++ b/lib/rundoc/code_command/website/visit.rb
@@ -1,6 +1,6 @@
 class Rundoc::CodeCommand::Website
   class Visit < Rundoc::CodeCommand
-    def initialize(name: , url: , scroll: nil, height: 720, width: 1024)
+    def initialize(name: , url: nil, scroll: nil, height: 720, width: 1024, visible: false)
       @name = name
       @url  = url
       @scroll = scroll
@@ -8,7 +8,8 @@ class Rundoc::CodeCommand::Website
         name: name,
         url: url,
         height: height,
-        width: width
+        width: width,
+        visible: visible
       )
       Driver.add(@name, @driver)
     end
@@ -23,12 +24,12 @@ class Rundoc::CodeCommand::Website
 
       puts message
 
-      @driver.visit(@url)
+      @driver.visit(@url) if @url
       @driver.scroll(@scroll) if @scroll
 
 
       return "" if contents.nil? || contents.empty?
-      @driver.send(:eval, contents)
+      @driver.safe_eval(contents)
 
       return ""
     end

--- a/test/fixtures/build_logs/rundoc.md
+++ b/test/fixtures/build_logs/rundoc.md
@@ -1,0 +1,56 @@
+Logs produced while building your application (deploying) are separated from your [runtime logs](https://devcenter.heroku.com/articles/logging#log-retrieval). The build logs for failed and successful deploys are available via the dashboard of the application.
+
+```
+:::-- $ touch Gemfile
+:::-- $ bundle _1.15.2_ install
+:::-- $ git init && git add . && git commit -m first
+:::-- $ heroku create
+:::-- $ git push heroku master
+```
+
+To view your build logs, first visit the dashboard for the application (`https://dashboard.heroku.com/apps/<app-name>`):
+
+```
+:::>> website.visit(name: "dashboard", url: "https://dashboard.heroku.com", visible: true)
+
+while current_url != "https://dashboard.heroku.com/apps"
+  puts "waiting for successful login: #{current_url}"
+  sleep 1
+end
+
+git_url = `git config --get remote.heroku.url`.chomp
+app_name = git_url.split("/").last.gsub(".git", "")
+session.visit "https://dashboard.heroku.com/apps/#{app_name}"
+sleep 2
+
+email = ENV['HEROKU_EMAIL'] || `heroku auth:whoami`
+session.execute_script %Q{$("span:contains(#{email}").html('developer@example.com')}
+
+:::>> website.screenshot(name: "dashboard", upload: "s3")
+```
+
+Next click on the "Activity" tab:
+
+```
+:::>> website.nav(name: "dashboard")
+session.first(:link, "Activity").click
+sleep 2
+
+email = ENV['HEROKU_EMAIL'] || `heroku auth:whoami`
+session.execute_script %Q{$("span:contains(#{email}").html('developer@example.com')}
+
+:::>> website.screenshot(name: "dashboard", upload: "s3")
+```
+
+From here you can click on "View build log" to see your most recent build:
+
+```
+:::>> website.nav(name: "dashboard")
+session.first(:link, "View build log").click
+sleep 2
+
+email = ENV['HEROKU_EMAIL'] || `heroku auth:whoami`
+session.execute_script %Q{$("span:contains(#{email}").html('developer@example.com')}
+
+:::>> website.screenshot(name: "dashboard", upload: "s3")
+```


### PR DESCRIPTION
Sometimes you might want to do something tricky, not easily scriptable. To allow for this you can now boot your selenium browser in non-headless mode by using `visible: true`.

To better support taking multiple screenshots of the same session over the course of a doc you can now `website.navigate` or `website.nav` which allows for control over an existing session.