### PR TITLE
Fix Log deletion bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+## 1.1.1
+
+- Fix log read race condition (https://github.com/schneems/rundoc/pull/25)
+
 ## 1.1.0
 
 - Pipe logic is now implemented through a parser (https://github.com/schneems/rundoc/pull/22)

--- a/lib/rundoc/code_command/background/process_spawn.rb
+++ b/lib/rundoc/code_command/background/process_spawn.rb
@@ -48,9 +48,9 @@ class Rundoc::CodeCommand::Background
     def initialize(command , timeout: 5, log: Tempfile.new("log"), out: "2>&1")
       @command = command
       @timeout_value = timeout
-      @log           = log
+      @log_reference = log # https://twitter.com/schneems/status/1285289971083907075
 
-      @log = Pathname.new(@log)
+      @log = Pathname.new(log)
       @log.dirname.mkpath
       FileUtils.touch(@log)
 

--- a/lib/rundoc/code_command/background/start.rb
+++ b/lib/rundoc/code_command/background/start.rb
@@ -26,9 +26,6 @@ class Rundoc::CodeCommand::Background
       @spawn.wait(@wait)
       @spawn.check_alive! unless @allow_fail
 
-      # WTF BBQ SAUCE
-      FileUtils.touch(@spawn.log)
-
       @spawn.log.read
     end
 

--- a/lib/rundoc/version.rb
+++ b/lib/rundoc/version.rb
@@ -1,3 +1,3 @@
 module Rundoc
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
A `Tempfile` works by defining a "finalizer" this is code that gets run when the object is cleaned up via GC. Here's a link:

https://github.com/ruby/ruby/blob/935d0b3d05dfc8b30bba505792129bf0e33ebe3b/lib/tempfile.rb#L132

As long as another object has a reference to a Tempfile then it will not be deleted from disk. In this scenario we're passing it to a `Pathname` object and it does not retain a reference to the passed in argument. You can reproduce this bug/behavior outside of Rundoc:

```
require 'pathname'
require 'tempfile'

def make_pathname(value = http://Tempfile.new("log"))
  http://Pathname.new(value)
end

p = make_pathname
FileUtils.touch(p)

puts "File: #{p.file?}"

GC.start

puts "File: #{p.file?}"
```

This generates:

```
$ ruby scratch.rb
File: true
File: false
```

This PR fixes the behavior by forcing a reference to the Tempfile object in the top level ProcessSpawn instance instead of expecting the Pathname `@log` instance variable to hold its reference.