### PR TITLE
Allow pipe commands to start with $

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## master
+## HEAD
+
+- Fix pipe support (https://github.com/schneems/rundoc/pull/28)
 
 ## 1.1.1
 

--- a/lib/rundoc/code_command/pipe.rb
+++ b/lib/rundoc/code_command/pipe.rb
@@ -8,6 +8,7 @@ module Rundoc
       def initialize(line)
         @delegate = parse(line)
       end
+
       # before: "",
       # after:  "",
       # commands:
@@ -25,15 +26,14 @@ module Rundoc
       end
 
       private def parse(code)
-        parser = Rundoc::PegParser.new.command
+        parser = Rundoc::PegParser.new.method_call
         tree = parser.parse(code)
         actual = Rundoc::PegTransformer.new.apply(tree)
 
-        if actual.is_a?(Array)
-          return actual.first
-        else
-          return actual
-        end
+        actual = actual.first if actual.is_a?(Array)
+
+        actual = Rundoc::CodeCommand::Bash.new(code) if actual.is_a?(Rundoc::CodeCommand::NoSuchCommand)
+        return actual
 
       # Since `| tail -n 2` does not start with a `$` assume any "naked" commands
       # are bash

--- a/test/fixtures/rails_6/rundoc.md
+++ b/test/fixtures/rails_6/rundoc.md
@@ -222,7 +222,7 @@ If you see `fatal: not in a git directory` then you are likely not in the correc
 Deploy your code:
 
 ```term
-:::>> $ git push heroku master
+:::>> $ git push heroku main || git push heroku master
 ```
 
 It is always a good idea to check to see if there are any warnings or errors in the output. If everything went well you can migrate your database.
@@ -376,7 +376,7 @@ Looks good, so press `Ctrl+C` to exit and you can deploy your changes to Heroku:
 ```term
 :::>- $ git add .
 :::>- $ git commit -m "use puma via procfile"
-:::>- $ git push heroku master
+:::>- $ git push heroku main || git push heroku master
 ```
 
 Check `ps`. You'll see that the web process uses your new command specifying Puma as the web server.

--- a/test/rundoc/code_commands/pipe_test.rb
+++ b/test/rundoc/code_commands/pipe_test.rb
@@ -1,12 +1,22 @@
 require 'test_helper'
 
 class PipeTest < Minitest::Test
-
   def test_pipe
     pipe_cmd = "tail -n 2"
     cmd      = "ls"
     out      = `#{cmd}`
     pipe     = Rundoc::CodeCommand::Pipe.new(pipe_cmd)
+    actual   = pipe.call(commands: [{command: cmd, output: out}])
+
+    expected = `#{cmd} | #{pipe_cmd}`
+    assert_equal expected, actual
+  end
+
+  def test_moar_pipe_with_dollar
+    pipe_cmd = "tail -n 2"
+    cmd      = "ls"
+    out      = `#{cmd}`
+    pipe     = Rundoc::CodeCommand::Pipe.new("$ #{pipe_cmd}")
     actual   = pipe.call(commands: [{command: cmd, output: out}])
 
     expected = `#{cmd} | #{pipe_cmd}`

--- a/test/rundoc/peg_parser_test.rb
+++ b/test/rundoc/peg_parser_test.rb
@@ -116,6 +116,16 @@ class PegParserTest < Minitest::Test
     assert_equal false, actual.result?
   end
 
+  def test_blerg_method_call
+    input = %Q{$ cat foo.rb}
+    parser = Rundoc::PegParser.new.method_call
+    tree = parser.parse_with_debug(input)
+
+    actual = @transformer.apply(tree)
+    assert_equal :"$", actual.keyword
+    assert_equal("cat foo.rb", actual.original_args)
+  end
+
   def test_command
     input = %Q{:::>> $ cat foo.rb\n}
     parser = Rundoc::PegParser.new.command


### PR DESCRIPTION
Pipe commands can take two forms:

```
| tail
```

and:

```
| $ tail
```

So that fully qualified commands can be used. There was a bug that commands that started with $ were not being used.

Prior to this the parser was expecting a `command` which looks like this:

```
    # :::>> $ cat foo.rb
    rule(:command) {
      (
        start_command >>
        visability.as(:cmd_visability) >> spaces? >>
        method_call.as(:cmd_method_call) >> newline.maybe #>> match(/\z/)
      ).as(:command)
    }
```

Which would never be matched. So we were accidentally relying on the failure rescue mode from the parser to give us the behavior for `| tail`.

With this change any commands should be allowed such as `| $ tail`.