### PR TITLE
Fix capturing STDERR output with ||

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Bugfix: Bash commands that output to stderr and use `||` are now captured (https://github.com/schneems/rundoc/pull/29)
+
 ## 1.1.2
 
 - Fix pipe support (https://github.com/schneems/rundoc/pull/28)

--- a/lib/rundoc/code_command/bash.rb
+++ b/lib/rundoc/code_command/bash.rb
@@ -32,12 +32,13 @@ class Rundoc::CodeCommand::Bash < Rundoc::CodeCommand
   end
 
   def shell(cmd, stdin = nil)
+    cmd = "(#{cmd}) 2>&1"
     msg  = "Running: $ '#{cmd}'"
     msg  << " with stdin: '#{stdin.inspect}'" if stdin && !stdin.empty?
     puts msg
 
     result = ""
-    IO.popen("#{cmd} 2>&1", "w+") do |io|
+    IO.popen(cmd, "w+") do |io|
       io << stdin if stdin
       io.close_write
       result = sanitize_escape_chars io.read

--- a/test/rundoc/code_commands/bash_test.rb
+++ b/test/rundoc/code_commands/bash_test.rb
@@ -11,6 +11,13 @@ class BashTest < Minitest::Test
     Dir.chdir(original_dir.strip)
   end
 
+  def test_bash_stderr_with_or_is_capture
+
+    command = "1>&2 echo 'msg to STDERR 1' || 1>&2 echo 'msg to STDERR 2'"
+    bash = Rundoc::CodeCommand::Bash.new(command)
+    assert_equal "$ #{command}", bash.to_md
+    assert_equal "msg to STDERR 1\n",   bash.call
+  end
 
   def test_bash_shells_and_shows_correctly
     ["pwd", "ls"].each do |command|


### PR DESCRIPTION
To support multiple branch names I had this in a rundoc:

```
:::>> $ git push heroku main || git push heroku master
```

Rundoc adds `2>&1` to the command so it got turned into:

```
git push heroku main || git push heroku master 2>&1
```

Which bash thinks that we mean we only want to redirect the output of the second command instead of both of them.

This can be fixed by grouping both with parens

```
(git push heroku main || git push heroku master) 2>&1
```