### PR TITLE
Defer runner instantiation to execution time

### DIFF
--- a/lib/rundoc.rb
+++ b/lib/rundoc.rb
@@ -10,10 +10,10 @@ module Rundoc
     original_args = args&.dup
 
     unless args_klass
-      command = Rundoc::CodeCommand::NoSuchCommand.new
-      command.keyword = keyword
-      command.original_args = original_args
-      return command
+      deferred = CodeCommand::Deferred.new(args_instance: nil, runner_klass: Rundoc::CodeCommand::NoSuchCommand)
+      deferred.keyword = keyword
+      deferred.original_args = original_args
+      return deferred
     end
 
     runner_klass = user_args_runner[keyword]

--- a/lib/rundoc.rb
+++ b/lib/rundoc.rb
@@ -9,25 +9,26 @@ module Rundoc
     args_klass = code_command(keyword.to_sym)
     original_args = args&.dup
 
-    unless args_klass
-      deferred = CodeCommand::Deferred.new(args_instance: nil, runner_klass: Rundoc::CodeCommand::NoSuchCommand)
-      deferred.keyword = keyword
-      deferred.original_args = original_args
-      return deferred
-    end
+    if args_klass
+      runner_klass = user_args_runner[keyword]
 
-    runner_klass = user_args_runner[keyword]
-
-    if args.is_a?(Array) && args.last.is_a?(Hash)
-      kwargs = args.pop
-      cc = args_klass.new(*args, **kwargs)
-    elsif args.is_a?(Hash)
-      cc = args_klass.new(**args)
+      if args.is_a?(Array) && args.last.is_a?(Hash)
+        kwargs = args.pop
+        user_args = args_klass.new(*args, **kwargs)
+      elsif args.is_a?(Hash)
+        user_args = args_klass.new(**args)
+      else
+        user_args = args_klass.new(*args)
+      end
     else
-      cc = args_klass.new(*args)
+      runner_klass = Rundoc::CodeCommand::NoSuchCommand
+      user_args = nil
     end
 
-    deferred = CodeCommand::Deferred.new(args_instance: cc, runner_klass: runner_klass)
+    deferred = CodeCommand::Deferred.new(
+      args_instance: user_args,
+      runner_klass: runner_klass
+    )
     deferred.original_args = original_args
     deferred.keyword = keyword
     deferred

--- a/lib/rundoc.rb
+++ b/lib/rundoc.rb
@@ -6,26 +6,31 @@ module Rundoc
   extend self
 
   def code_command_from_keyword(keyword, args)
-    klass = code_command(keyword.to_sym) || Rundoc::CodeCommand::NoSuchCommand
-    original_args = args.dup
+    args_klass = code_command(keyword.to_sym)
+    original_args = args&.dup
+
+    unless args_klass
+      command = Rundoc::CodeCommand::NoSuchCommand.new
+      command.keyword = keyword
+      command.original_args = original_args
+      return command
+    end
+
+    runner_klass = user_args_runner[keyword]
+
     if args.is_a?(Array) && args.last.is_a?(Hash)
       kwargs = args.pop
-      cc = klass.new(*args, **kwargs)
+      cc = args_klass.new(*args, **kwargs)
     elsif args.is_a?(Hash)
-      cc = klass.new(**args)
+      cc = args_klass.new(**args)
     else
-      cc = klass.new(*args)
+      cc = args_klass.new(*args)
     end
 
-    command = if (runner = user_args_runner[keyword])
-      runner.new(user_args: cc)
-    else
-      cc
-    end
-
-    command.original_args = original_args
-    command.keyword = keyword
-    command
+    deferred = CodeCommand::Deferred.new(args_instance: cc, runner_klass: runner_klass)
+    deferred.original_args = original_args
+    deferred.keyword = keyword
+    deferred
   rescue ArgumentError => e
     raise ArgumentError, "Wrong method signature for #{keyword} with arguments: #{original_args.inspect}, error:\n #{e.message}"
   end

--- a/lib/rundoc/code_command.rb
+++ b/lib/rundoc/code_command.rb
@@ -50,6 +50,7 @@ module Rundoc
   end
 end
 
+require "rundoc/code_command/deferred"
 require "rundoc/code_command/bash"
 require "rundoc/code_command/pipe"
 require "rundoc/code_command/write"

--- a/lib/rundoc/code_command/deferred.rb
+++ b/lib/rundoc/code_command/deferred.rb
@@ -1,5 +1,9 @@
 module Rundoc
   class CodeCommand
+    # Hold enough information to construct commands, but don't yet
+    #
+    # Allows us to separate parse time constructs from runtime injectables
+    # (such as IO). Which gives us a cleaner running model.
     class Deferred
       attr_accessor :render_result, :render_command,
         :contents, :keyword, :original_args

--- a/lib/rundoc/code_command/deferred.rb
+++ b/lib/rundoc/code_command/deferred.rb
@@ -1,0 +1,48 @@
+module Rundoc
+  class CodeCommand
+    class Deferred
+      attr_accessor :render_result, :render_command,
+        :contents, :keyword, :original_args
+
+      alias_method :render_result?, :render_result
+      alias_method :render_command?, :render_command
+
+      def initialize(args_instance:, runner_klass:)
+        @args_instance = args_instance
+        @runner_klass = runner_klass
+      end
+
+      def hidden?
+        !render_command? && !render_result?
+      end
+
+      def not_hidden?
+        !hidden?
+      end
+
+      def push(contents)
+        @contents ||= ""
+        @contents << contents
+      end
+      alias_method :<<, :push
+
+      def build
+        runner = @runner_klass.new(user_args: @args_instance)
+        runner.render_command = render_command
+        runner.render_result = render_result
+        runner.keyword = keyword
+        runner.original_args = original_args
+        runner.push(@contents) if @contents && !@contents.empty?
+        runner
+      end
+
+      def call(env = {})
+        build.call(env)
+      end
+
+      def to_md(env = {})
+        build.to_md(env)
+      end
+    end
+  end
+end

--- a/lib/rundoc/code_command/deferred.rb
+++ b/lib/rundoc/code_command/deferred.rb
@@ -13,7 +13,11 @@ module Rundoc
       end
 
       def hidden?
-        !render_command? && !render_result?
+        if @built
+          @built.hidden?
+        else
+          !render_command? && !render_result?
+        end
       end
 
       def not_hidden?
@@ -27,13 +31,15 @@ module Rundoc
       alias_method :<<, :push
 
       def build
-        runner = @runner_klass.new(user_args: @args_instance)
-        runner.render_command = render_command
-        runner.render_result = render_result
-        runner.keyword = keyword
-        runner.original_args = original_args
-        runner.push(@contents) if @contents && !@contents.empty?
-        runner
+        @built ||= begin
+          runner = @runner_klass.new(user_args: @args_instance)
+          runner.render_command = render_command
+          runner.render_result = render_result
+          runner.keyword = keyword
+          runner.original_args = original_args
+          runner.push(@contents) if @contents && !@contents.empty?
+          runner
+        end
       end
 
       def call(env = {})

--- a/lib/rundoc/code_command/deferred.rb
+++ b/lib/rundoc/code_command/deferred.rb
@@ -7,6 +7,8 @@ module Rundoc
       alias_method :render_result?, :render_result
       alias_method :render_command?, :render_command
 
+      attr_reader :runner_klass
+
       def initialize(args_instance:, runner_klass:)
         @args_instance = args_instance
         @runner_klass = runner_klass

--- a/lib/rundoc/code_command/no_such_command.rb
+++ b/lib/rundoc/code_command/no_such_command.rb
@@ -1,8 +1,11 @@
 module Rundoc
   class CodeCommand
     class NoSuchCommand < Rundoc::CodeCommand
+      def initialize(user_args: nil)
+      end
+
       def call(env = {})
-        raise "No such command registered with rundoc: #{@keyword.inspect} for '#{@keyword} #{@original_args}'"
+        raise "No such command registered with rundoc: #{keyword.inspect} for '#{keyword} #{original_args}'"
       end
     end
   end

--- a/lib/rundoc/code_command/pipe.rb
+++ b/lib/rundoc/code_command/pipe.rb
@@ -36,6 +36,7 @@ module Rundoc
 
         actual = actual.first if actual.is_a?(Array)
 
+        # Unregistered keywords (e.g. `| tail -n 2`) aren't rundoc commands — treat them as bash
         if actual.runner_klass == Rundoc::CodeCommand::NoSuchCommand
           actual = Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new(code))
         end

--- a/lib/rundoc/code_command/pipe.rb
+++ b/lib/rundoc/code_command/pipe.rb
@@ -36,7 +36,9 @@ module Rundoc
 
         actual = actual.first if actual.is_a?(Array)
 
-        actual = Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new(code)) if actual.is_a?(Rundoc::CodeCommand::NoSuchCommand)
+        if actual.runner_klass == Rundoc::CodeCommand::NoSuchCommand
+          actual = Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new(code))
+        end
         actual
 
       # Since `| tail -n 2` does not start with a `$` assume any "naked" commands

--- a/lib/rundoc/fenced_code_block.rb
+++ b/lib/rundoc/fenced_code_block.rb
@@ -55,7 +55,13 @@ module Rundoc
       env[:context] = @context
       env[:stack] = @stack
 
-      while (code_command = @stack.pop)
+      while (item = @stack.pop)
+        code_command = if item.is_a?(CodeCommand::Deferred)
+          item.build
+        else
+          item
+        end
+
         code_output = code_command.call(env) || ""
         code_line = code_command.to_md(env) || ""
         result << code_line if code_command.render_command?


### PR DESCRIPTION
Prerequisite for IO dependency injection. By deferring runner construction to execution time, we create a seam where runtime values (like `io:`) can be threaded through at build time rather than requiring them at parse time.

Stack: 1/4 → #111 → #113 → #114