### PR TITLE
Clean up CodeCommand internals

### DIFF
--- a/lib/rundoc.rb
+++ b/lib/rundoc.rb
@@ -5,6 +5,8 @@ require "rundoc/version"
 module Rundoc
   extend self
 
+  class UnknownCommand < StandardError; end
+
   def code_command_from_keyword(keyword, args)
     args_klass = code_command(keyword.to_sym)
     original_args = args&.dup

--- a/lib/rundoc/code_command.rb
+++ b/lib/rundoc/code_command.rb
@@ -14,7 +14,7 @@ module Rundoc
     end
 
     attr_accessor :render_result, :render_command,
-      :command, :contents, :keyword,
+      :contents, :keyword,
       :original_args
 
     alias_method :render_result?, :render_result

--- a/lib/rundoc/code_command.rb
+++ b/lib/rundoc/code_command.rb
@@ -2,15 +2,20 @@ module Rundoc
   # Generic CodeCommand class to be inherited
   #
   class CodeCommand
-    attr_accessor :render_result, :render_command, :contents
+    attr_accessor :contents
 
-    alias_method :render_result?, :render_result
-    alias_method :render_command?, :render_command
-
-    def initialize(render_command: nil, render_result: nil, contents: nil)
+    def initialize(render_command:, render_result:, contents: nil)
       @render_command = render_command
       @render_result = render_result
       push(contents) if contents && !contents.empty?
+    end
+
+    def render_result?
+      @render_result
+    end
+
+    def render_command?
+      @render_command
     end
 
     def hidden?

--- a/lib/rundoc/code_command.rb
+++ b/lib/rundoc/code_command.rb
@@ -2,17 +2,6 @@ module Rundoc
   # Generic CodeCommand class to be inherited
   #
   class CodeCommand
-    # Newlines are stripped and re-added, this tells the project that
-    # we're intentionally wanting an extra newline
-    NEWLINE = Object.new
-    def NEWLINE.to_s
-      ""
-    end
-
-    def NEWLINE.empty?
-      false
-    end
-
     attr_accessor :render_result, :render_command, :contents
 
     alias_method :render_result?, :render_result

--- a/lib/rundoc/code_command.rb
+++ b/lib/rundoc/code_command.rb
@@ -18,7 +18,10 @@ module Rundoc
     alias_method :render_result?, :render_result
     alias_method :render_command?, :render_command
 
-    def initialize(*args)
+    def initialize(render_command: nil, render_result: nil, contents: nil)
+      @render_command = render_command
+      @render_result = render_result
+      push(contents) if contents && !contents.empty?
     end
 
     def hidden?

--- a/lib/rundoc/code_command.rb
+++ b/lib/rundoc/code_command.rb
@@ -13,9 +13,7 @@ module Rundoc
       false
     end
 
-    attr_accessor :render_result, :render_command,
-      :contents, :keyword,
-      :original_args
+    attr_accessor :render_result, :render_command, :contents
 
     alias_method :render_result?, :render_result
     alias_method :render_command?, :render_command

--- a/lib/rundoc/code_command/background/log/clear.rb
+++ b/lib/rundoc/code_command/background/log/clear.rb
@@ -8,9 +8,10 @@ class Rundoc::CodeCommand::Background::Log
   end
 
   class ClearRunner < Rundoc::CodeCommand
-    def initialize(user_args:)
+    def initialize(user_args:, **)
       @name = user_args.name
       @background = nil
+      super(**)
     end
 
     def background

--- a/lib/rundoc/code_command/background/log/read.rb
+++ b/lib/rundoc/code_command/background/log/read.rb
@@ -8,9 +8,10 @@ class Rundoc::CodeCommand::Background::Log
   end
 
   class ReadRunner < Rundoc::CodeCommand
-    def initialize(user_args:)
+    def initialize(user_args:, **)
       @name = user_args.name
       @background = nil
+      super(**)
     end
 
     def background

--- a/lib/rundoc/code_command/background/start.rb
+++ b/lib/rundoc/code_command/background/start.rb
@@ -16,7 +16,7 @@ class Rundoc::CodeCommand::Background
   end
 
   class StartRunner < Rundoc::CodeCommand
-    def initialize(user_args:)
+    def initialize(user_args:, **)
       @timeout = user_args.timeout
       @command = user_args.command
       @name = user_args.name
@@ -27,6 +27,7 @@ class Rundoc::CodeCommand::Background
       FileUtils.touch(@log)
 
       @background = nil
+      super(**)
     end
 
     def background

--- a/lib/rundoc/code_command/background/stdin_write.rb
+++ b/lib/rundoc/code_command/background/stdin_write.rb
@@ -12,7 +12,7 @@ class Rundoc::CodeCommand::Background
   end
 
   class StdinWriteRunner < Rundoc::CodeCommand
-    def initialize(user_args:)
+    def initialize(user_args:, **)
       @contents = user_args.contents
       @ending = user_args.ending
       @wait = user_args.wait
@@ -20,6 +20,7 @@ class Rundoc::CodeCommand::Background
       @timeout_value = user_args.timeout
       @contents_written = nil
       @background = nil
+      super(**)
     end
 
     def background

--- a/lib/rundoc/code_command/background/stop.rb
+++ b/lib/rundoc/code_command/background/stop.rb
@@ -8,9 +8,10 @@ class Rundoc::CodeCommand::Background
   end
 
   class StopRunner < Rundoc::CodeCommand
-    def initialize(user_args:)
+    def initialize(user_args:, **)
       @name = user_args.name
       @background = nil
+      super(**)
     end
 
     def background

--- a/lib/rundoc/code_command/background/wait.rb
+++ b/lib/rundoc/code_command/background/wait.rb
@@ -10,11 +10,12 @@ class Rundoc::CodeCommand::Background
   end
 
   class WaitRunner < Rundoc::CodeCommand
-    def initialize(user_args:)
+    def initialize(user_args:, **)
       @name = user_args.name
       @wait = user_args.wait
       @timeout_value = user_args.timeout
       @background = nil
+      super(**)
     end
 
     def background

--- a/lib/rundoc/code_command/bash.rb
+++ b/lib/rundoc/code_command/bash.rb
@@ -18,6 +18,11 @@ class Rundoc::CodeCommand::BashRunner < Rundoc::CodeCommand
     end
   end
 
+  # predicate to over-write for failure support
+  def raise_on_error?
+    true
+  end
+
   def to_md(env = {})
     return @delegate.to_md(env) if @delegate
 
@@ -54,15 +59,25 @@ class Rundoc::CodeCommand::BashRunner < Rundoc::CodeCommand
       end
     end
 
-    unless $?.success?
-      raise "Command `#{@line}` exited with non zero status: #{result}" unless keyword.to_s.include?("fail")
+    if raise_on_error? && !$?.success?
+      raise "Command `#{@line}` exited with non zero status: #{result}"
     end
     result
   end
 end
 
+class Rundoc::CodeCommand::BashRunnerFailOk < Rundoc::CodeCommand::BashRunner
+  def raise_on_error?
+    false
+  end
+end
+
 Rundoc.register_code_command(keyword: :bash, args_klass: Rundoc::CodeCommand::BashArgs, runner_klass: Rundoc::CodeCommand::BashRunner)
 Rundoc.register_code_command(keyword: :"$", args_klass: Rundoc::CodeCommand::BashArgs, runner_klass: Rundoc::CodeCommand::BashRunner)
-Rundoc.register_code_command(keyword: :"fail.$", args_klass: Rundoc::CodeCommand::BashArgs, runner_klass: Rundoc::CodeCommand::BashRunner)
+Rundoc.register_code_command(
+  keyword: :"fail.$",
+  args_klass: Rundoc::CodeCommand::BashArgs,
+  runner_klass: Rundoc::CodeCommand::BashRunnerFailOk
+)
 
 require "rundoc/code_command/bash/cd"

--- a/lib/rundoc/code_command/bash.rb
+++ b/lib/rundoc/code_command/bash.rb
@@ -7,7 +7,7 @@ class Rundoc::CodeCommand::BashArgs
 end
 
 class Rundoc::CodeCommand::BashRunner < Rundoc::CodeCommand
-  def initialize(user_args:)
+  def initialize(user_args:, **)
     @line = user_args.line
     @contents = ""
     @delegate = case @line.split(" ").first.downcase
@@ -16,6 +16,7 @@ class Rundoc::CodeCommand::BashRunner < Rundoc::CodeCommand
     else
       false
     end
+    super(**)
   end
 
   # predicate to over-write for failure support

--- a/lib/rundoc/code_command/deferred.rb
+++ b/lib/rundoc/code_command/deferred.rb
@@ -41,11 +41,11 @@ module Rundoc
           runner = @runner_klass.new(user_args: @args_instance)
           runner.render_command = render_command
           runner.render_result = render_result
-          runner.keyword = keyword
-          runner.original_args = original_args
           runner.push(@contents) if @contents && !@contents.empty?
           runner
         end
+      rescue UnknownCommand
+        raise "No such command registered with rundoc #{keyword.inspect} for `#{keyword} #{original_args}`"
       end
 
       def call(env = {})

--- a/lib/rundoc/code_command/deferred.rb
+++ b/lib/rundoc/code_command/deferred.rb
@@ -37,13 +37,12 @@ module Rundoc
       alias_method :<<, :push
 
       def build
-        @built ||= begin
-          runner = @runner_klass.new(user_args: @args_instance)
-          runner.render_command = render_command
-          runner.render_result = render_result
-          runner.push(@contents) if @contents && !@contents.empty?
-          runner
-        end
+        @built ||= @runner_klass.new(
+          user_args: @args_instance,
+          render_command: render_command,
+          render_result: render_result,
+          contents: @contents
+        )
       rescue UnknownCommand
         raise "No such command registered with rundoc #{keyword.inspect} for `#{keyword} #{original_args}`"
       end

--- a/lib/rundoc/code_command/file_command/append.rb
+++ b/lib/rundoc/code_command/file_command/append.rb
@@ -10,11 +10,12 @@ class Rundoc::CodeCommand::FileCommand
   class AppendRunner < Rundoc::CodeCommand
     include FileUtil
 
-    def initialize(user_args:)
+    def initialize(user_args:, **)
       @filename, line = user_args.filename.split("#")
       @line_number = if line
         Integer(line)
       end
+      super(**)
     end
 
     def to_md(env)

--- a/lib/rundoc/code_command/file_command/remove.rb
+++ b/lib/rundoc/code_command/file_command/remove.rb
@@ -10,8 +10,9 @@ class Rundoc::CodeCommand::FileCommand
   class RemoveRunner < Rundoc::CodeCommand
     include FileUtil
 
-    def initialize(user_args:)
+    def initialize(user_args:, **)
       @filename = user_args.filename
+      super(**)
     end
 
     def to_md(env)

--- a/lib/rundoc/code_command/file_command/remove.rb
+++ b/lib/rundoc/code_command/file_command/remove.rb
@@ -8,6 +8,16 @@ class Rundoc::CodeCommand::FileCommand
   end
 
   class RemoveRunner < Rundoc::CodeCommand
+    # Newlines are stripped and re-added, this tells the project that
+    # we're intentionally wanting an extra newline
+    NEWLINE = Object.new
+    def NEWLINE.to_s
+      ""
+    end
+
+    def NEWLINE.empty?
+      false
+    end
     include FileUtil
 
     def initialize(user_args:, **)

--- a/lib/rundoc/code_command/no_such_command.rb
+++ b/lib/rundoc/code_command/no_such_command.rb
@@ -1,7 +1,8 @@
 module Rundoc
   class CodeCommand
     class NoSuchCommand < Rundoc::CodeCommand
-      def initialize(user_args: nil)
+      def initialize(user_args: nil, **)
+        super(**)
       end
 
       def call(env = {})

--- a/lib/rundoc/code_command/no_such_command.rb
+++ b/lib/rundoc/code_command/no_such_command.rb
@@ -5,7 +5,7 @@ module Rundoc
       end
 
       def call(env = {})
-        raise "No such command registered with rundoc: #{keyword.inspect} for '#{keyword} #{original_args}'"
+        raise UnknownCommand
       end
     end
   end

--- a/lib/rundoc/code_command/pipe.rb
+++ b/lib/rundoc/code_command/pipe.rb
@@ -39,14 +39,14 @@ module Rundoc
 
         # Unregistered keywords (e.g. `| tail -n 2`) aren't rundoc commands — treat them as bash
         if actual.runner_klass == Rundoc::CodeCommand::NoSuchCommand
-          actual = Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new(code))
+          actual = Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new(code), render_command: false, render_result: false)
         end
         actual
 
       # Since `| tail -n 2` does not start with a `$` assume any "naked" commands
       # are bash
       rescue Parslet::ParseFailed
-        Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new(code))
+        Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new(code), render_command: false, render_result: false)
       end
     end
   end

--- a/lib/rundoc/code_command/pipe.rb
+++ b/lib/rundoc/code_command/pipe.rb
@@ -9,8 +9,9 @@ module Rundoc
     end
 
     class PipeRunner < Rundoc::CodeCommand
-      def initialize(user_args:)
+      def initialize(user_args:, **)
         @delegate = parse(user_args.line)
+        super(**)
       end
 
       # before: "",

--- a/lib/rundoc/code_command/pre/erb.rb
+++ b/lib/rundoc/code_command/pre/erb.rb
@@ -10,7 +10,7 @@ class Rundoc::CodeCommand
   end
 
   class PreErbRunner < Rundoc::CodeCommand
-    def initialize(user_args:, render_command: nil, render_result: nil, contents: nil)
+    def initialize(user_args:, render_command:, render_result:, contents: nil)
       @line = user_args.line
       @binding = RUNDOC_ERB_BINDINGS[RUNDOC_DEFAULT_ERB_BINDING]
       @code = nil

--- a/lib/rundoc/code_command/pre/erb.rb
+++ b/lib/rundoc/code_command/pre/erb.rb
@@ -10,26 +10,17 @@ class Rundoc::CodeCommand
   end
 
   class PreErbRunner < Rundoc::CodeCommand
-    def initialize(user_args:)
+    def initialize(user_args:, render_command: nil, render_result: nil, contents: nil)
       @line = user_args.line
       @binding = RUNDOC_ERB_BINDINGS[RUNDOC_DEFAULT_ERB_BINDING]
       @code = nil
       @command = nil
       @template = nil
-      @render_delegate_result = nil
-      @render_delegate_command = nil
-      # Hide self, pass visibility onto delegate
+      @render_delegate_result = render_result
+      @render_delegate_command = render_command
       @render_result = false
       @render_command = false
-    end
-
-    # Visibility is injected by the parser, capture it and pass it to the delegate
-    def render_result=(value)
-      @render_delegate_result = value
-    end
-
-    def render_command=(value)
-      @render_delegate_command = value
+      push(contents) if contents && !contents.empty?
     end
 
     def code

--- a/lib/rundoc/code_command/print/erb.rb
+++ b/lib/rundoc/code_command/print/erb.rb
@@ -24,9 +24,10 @@ class Rundoc::CodeCommand
   end
 
   class PrintERBRunner < Rundoc::CodeCommand
-    def initialize(user_args:)
+    def initialize(user_args:, **)
       @line = user_args.line
       @binding = RUNDOC_ERB_BINDINGS[user_args.binding_name]
+      super(**)
     end
 
     def to_md(env)

--- a/lib/rundoc/code_command/print/text.rb
+++ b/lib/rundoc/code_command/print/text.rb
@@ -8,8 +8,9 @@ class Rundoc::CodeCommand
   end
 
   class PrintTextRunner < Rundoc::CodeCommand
-    def initialize(user_args:)
+    def initialize(user_args:, **)
       @line = user_args.line
+      super(**)
     end
 
     def to_md(env)

--- a/lib/rundoc/code_command/rundoc/require.rb
+++ b/lib/rundoc/code_command/rundoc/require.rb
@@ -10,8 +10,9 @@ class ::Rundoc::CodeCommand
     end
 
     class RequireRunner < ::Rundoc::CodeCommand
-      def initialize(user_args:)
+      def initialize(user_args:, **)
         @path = user_args.path
+        super(**)
       end
 
       def to_md(env = {})

--- a/lib/rundoc/code_command/rundoc_command.rb
+++ b/lib/rundoc/code_command/rundoc_command.rb
@@ -9,8 +9,9 @@ module ::Rundoc
     end
 
     class RundocCommandRunner < ::Rundoc::CodeCommand
-      def initialize(user_args:)
+      def initialize(user_args:, **)
         @contents = user_args.contents
+        super(**)
       end
 
       def to_md(env = {})

--- a/lib/rundoc/code_command/website/navigate.rb
+++ b/lib/rundoc/code_command/website/navigate.rb
@@ -8,9 +8,10 @@ class Rundoc::CodeCommand::Website
   end
 
   class NavigateRunner < Rundoc::CodeCommand
-    def initialize(user_args:)
+    def initialize(user_args:, **)
       @name = user_args.name
       @driver = nil
+      super(**)
     end
 
     def driver

--- a/lib/rundoc/code_command/website/screenshot.rb
+++ b/lib/rundoc/code_command/website/screenshot.rb
@@ -9,10 +9,11 @@ class Rundoc::CodeCommand::Website
   end
 
   class ScreenshotRunner < Rundoc::CodeCommand
-    def initialize(user_args:)
+    def initialize(user_args:, **)
       @name = user_args.name
       @upload = user_args.upload
       @driver = nil
+      super(**)
     end
 
     def driver

--- a/lib/rundoc/code_command/website/visit.rb
+++ b/lib/rundoc/code_command/website/visit.rb
@@ -16,7 +16,7 @@ class Rundoc::CodeCommand::Website
   end
 
   class VisitRunner < Rundoc::CodeCommand
-    def initialize(user_args:)
+    def initialize(user_args:, **)
       @name = user_args.name
       @url = user_args.url
       @scroll = user_args.scroll
@@ -24,6 +24,7 @@ class Rundoc::CodeCommand::Website
       @width = user_args.width
       @visible = user_args.visible
       @max_attempts = user_args.max_attempts
+      super(**)
     end
 
     def driver

--- a/lib/rundoc/code_command/write.rb
+++ b/lib/rundoc/code_command/write.rb
@@ -24,6 +24,17 @@ module Rundoc
     end
 
     class WriteRunner < Rundoc::CodeCommand
+      # Newlines are stripped and re-added, this tells the project that
+      # we're intentionally wanting an extra newline
+      NEWLINE = Object.new
+      def NEWLINE.to_s
+        ""
+      end
+
+      def NEWLINE.empty?
+        false
+      end
+
       include FileUtil
 
       def initialize(user_args:, **)

--- a/lib/rundoc/code_command/write.rb
+++ b/lib/rundoc/code_command/write.rb
@@ -26,8 +26,9 @@ module Rundoc
     class WriteRunner < Rundoc::CodeCommand
       include FileUtil
 
-      def initialize(user_args:)
+      def initialize(user_args:, **)
         @filename = user_args.path.to_s
+        super(**)
       end
 
       def to_md(env)

--- a/test/rundoc/code_commands/append_file_test.rb
+++ b/test/rundoc/code_commands/append_file_test.rb
@@ -7,7 +7,7 @@ class AppendFileTest < Minitest::Test
         file = "foo.rb"
         `echo 'foo' >> #{file}`
 
-        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file))
+        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file))
         cc << "bar"
         cc.call
 
@@ -16,7 +16,7 @@ class AppendFileTest < Minitest::Test
         assert_match(/foo/, result)
         assert_match(/bar/, result)
 
-        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file))
+        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file))
         cc << "baz"
         cc.call
 
@@ -39,7 +39,7 @@ class AppendFileTest < Minitest::Test
         line = 2
         `echo '#{contents}' >> #{file}`
 
-        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("#{file}##{line}"))
+        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("#{file}##{line}"))
         cc << "gem 'pg'"
         cc.call
 
@@ -54,7 +54,7 @@ class AppendFileTest < Minitest::Test
       Dir.chdir(dir) do
         filename = "file-#{Time.now.utc.strftime("%Y%m%d%H%M%S")}.txt"
         FileUtils.touch(filename)
-        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("file-*.txt"))
+        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("file-*.txt"))
         cc << "some text"
         cc.call
 
@@ -69,7 +69,7 @@ class AppendFileTest < Minitest::Test
         FileUtils.touch("file-1234.txt")
         FileUtils.touch("file-5678.txt")
         assert_raises do
-          cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("file-*.txt"))
+          cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("file-*.txt"))
           cc << "some text"
           cc.call
         end

--- a/test/rundoc/code_commands/background_test.rb
+++ b/test/rundoc/code_commands/background_test.rb
@@ -23,14 +23,12 @@ class BackgroundTest < Minitest::Test
           user_args: Rundoc::CodeCommand::Background::WaitArgs.new(
             name: "cat",
             wait: "hello"
-          )
-        ).call
+          )).call
 
         Rundoc::CodeCommand::Background::Log::ClearRunner.new(render_command: false, render_result: false,
           user_args: Rundoc::CodeCommand::Background::Log::ClearArgs.new(
             name: "cat"
-          )
-        ).call
+          )).call
 
         output = Rundoc::CodeCommand::Background::StdinWriteRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::StdinWriteArgs.new(
           "general kenobi",
@@ -86,7 +84,7 @@ class BackgroundTest < Minitest::Test
 
         assert_equal("foo", output.chomp)
 
-        log_clear = Rundoc::CodeCommand::Background::Log::ClearRunner.new(render_command: false, render_result: false,user_args: Rundoc::CodeCommand::Background::Log::ClearArgs.new(name: "tail"))
+        log_clear = Rundoc::CodeCommand::Background::Log::ClearRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::Log::ClearArgs.new(name: "tail"))
         output = log_clear.call
         assert_equal("", output)
 

--- a/test/rundoc/code_commands/background_test.rb
+++ b/test/rundoc/code_commands/background_test.rb
@@ -6,33 +6,33 @@ class BackgroundTest < Minitest::Test
       Dir.chdir(dir) do
         # Intentionally out of order, should not raise an error as long as "cat"
         # command exists at execution time
-        stdin_write = Rundoc::CodeCommand::Background::StdinWriteRunner.new(user_args: Rundoc::CodeCommand::Background::StdinWriteArgs.new(
+        stdin_write = Rundoc::CodeCommand::Background::StdinWriteRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::StdinWriteArgs.new(
           "hello there",
           name: "cat",
           wait: "hello"
         ))
 
-        background_start = Rundoc::CodeCommand::Background::StartRunner.new(user_args: Rundoc::CodeCommand::Background::StartArgs.new("cat",
+        background_start = Rundoc::CodeCommand::Background::StartRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::StartArgs.new("cat",
           name: "cat"))
 
         background_start.call
         output = stdin_write.call
         assert_equal("hello there" + $/, output)
 
-        Rundoc::CodeCommand::Background::WaitRunner.new(
+        Rundoc::CodeCommand::Background::WaitRunner.new(render_command: false, render_result: false,
           user_args: Rundoc::CodeCommand::Background::WaitArgs.new(
             name: "cat",
             wait: "hello"
           )
         ).call
 
-        Rundoc::CodeCommand::Background::Log::ClearRunner.new(
+        Rundoc::CodeCommand::Background::Log::ClearRunner.new(render_command: false, render_result: false,
           user_args: Rundoc::CodeCommand::Background::Log::ClearArgs.new(
             name: "cat"
           )
         ).call
 
-        output = Rundoc::CodeCommand::Background::StdinWriteRunner.new(user_args: Rundoc::CodeCommand::Background::StdinWriteArgs.new(
+        output = Rundoc::CodeCommand::Background::StdinWriteRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::StdinWriteArgs.new(
           "general kenobi",
           name: "cat",
           wait: "general"
@@ -48,7 +48,7 @@ class BackgroundTest < Minitest::Test
         file = "foo.txt"
         run!("echo 'foo' >> #{file}")
 
-        background_start = Rundoc::CodeCommand::Background::StartRunner.new(user_args: Rundoc::CodeCommand::Background::StartArgs.new("tail -f #{file}",
+        background_start = Rundoc::CodeCommand::Background::StartRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::StartArgs.new("tail -f #{file}",
           name: "tail2",
           wait: "f"))
 
@@ -59,7 +59,7 @@ class BackgroundTest < Minitest::Test
         assert_match("foo", output)
         assert_equal(true, background_start.alive?)
 
-        background_stop = Rundoc::CodeCommand::Background::StopRunner.new(user_args: Rundoc::CodeCommand::Background::StopArgs.new(name: "tail2"))
+        background_stop = Rundoc::CodeCommand::Background::StopRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::StopArgs.new(name: "tail2"))
         background_stop.call
 
         assert_equal(false, background_start.alive?)
@@ -73,7 +73,7 @@ class BackgroundTest < Minitest::Test
         file = "foo.txt"
         run!("echo 'foo' >> #{file}")
 
-        background_start = Rundoc::CodeCommand::Background::StartRunner.new(user_args: Rundoc::CodeCommand::Background::StartArgs.new("tail -f #{file}",
+        background_start = Rundoc::CodeCommand::Background::StartRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::StartArgs.new("tail -f #{file}",
           name: "tail",
           wait: "f"))
         output = background_start.call
@@ -81,12 +81,12 @@ class BackgroundTest < Minitest::Test
         assert_match("foo", output)
         assert_equal(true, background_start.alive?)
 
-        log_read = Rundoc::CodeCommand::Background::Log::ReadRunner.new(user_args: Rundoc::CodeCommand::Background::Log::ReadArgs.new(name: "tail"))
+        log_read = Rundoc::CodeCommand::Background::Log::ReadRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::Log::ReadArgs.new(name: "tail"))
         output = log_read.call
 
         assert_equal("foo", output.chomp)
 
-        log_clear = Rundoc::CodeCommand::Background::Log::ClearRunner.new(user_args: Rundoc::CodeCommand::Background::Log::ClearArgs.new(name: "tail"))
+        log_clear = Rundoc::CodeCommand::Background::Log::ClearRunner.new(render_command: false, render_result: false,user_args: Rundoc::CodeCommand::Background::Log::ClearArgs.new(name: "tail"))
         output = log_clear.call
         assert_equal("", output)
 
@@ -94,12 +94,12 @@ class BackgroundTest < Minitest::Test
 
         background_start.background.wait("bar")
 
-        log_read = Rundoc::CodeCommand::Background::Log::ReadRunner.new(user_args: Rundoc::CodeCommand::Background::Log::ReadArgs.new(name: "tail"))
+        log_read = Rundoc::CodeCommand::Background::Log::ReadRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::Log::ReadArgs.new(name: "tail"))
         output = log_read.call
 
         assert_equal("bar", output.chomp)
 
-        background_stop = Rundoc::CodeCommand::Background::StopRunner.new(user_args: Rundoc::CodeCommand::Background::StopArgs.new(name: "tail"))
+        background_stop = Rundoc::CodeCommand::Background::StopRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::StopArgs.new(name: "tail"))
         background_stop.call
 
         assert_equal(false, background_start.alive?)

--- a/test/rundoc/code_commands/bash_test.rb
+++ b/test/rundoc/code_commands/bash_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class BashTest < Minitest::Test
   def test_bash_returns_cd
     original_dir = `pwd`
-    Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new("cd ..")).call
+    Rundoc::CodeCommand::BashRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::BashArgs.new("cd ..")).call
     now_dir = `pwd`
     refute_equal original_dir, now_dir
   ensure
@@ -12,14 +12,14 @@ class BashTest < Minitest::Test
 
   def test_bash_stderr_with_or_is_capture
     command = "1>&2 echo 'msg to STDERR 1' || 1>&2 echo 'msg to STDERR 2'"
-    bash = Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new(command))
+    bash = Rundoc::CodeCommand::BashRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::BashArgs.new(command))
     assert_equal "$ #{command}", bash.to_md
     assert_equal "msg to STDERR 1\n", bash.call
   end
 
   def test_bash_shells_and_shows_correctly
     ["pwd", "ls"].each do |command|
-      bash = Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new(command))
+      bash = Rundoc::CodeCommand::BashRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::BashArgs.new(command))
       assert_equal "$ #{command}", bash.to_md
       assert_equal `#{command}`, bash.call
     end
@@ -27,7 +27,7 @@ class BashTest < Minitest::Test
 
   def test_stdin
     command = "tail -n 2"
-    bash = Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new(command))
+    bash = Rundoc::CodeCommand::BashRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::BashArgs.new(command))
     bash << "foo\nbar\nbaz\n"
     assert_equal "bar\nbaz\n", bash.call
   end

--- a/test/rundoc/code_commands/pipe_test.rb
+++ b/test/rundoc/code_commands/pipe_test.rb
@@ -5,7 +5,7 @@ class PipeTest < Minitest::Test
     pipe_cmd = "tail -n 2"
     cmd = "ls"
     out = `#{cmd}`
-    pipe = Rundoc::CodeCommand::PipeRunner.new(user_args: Rundoc::CodeCommand::PipeArgs.new(pipe_cmd))
+    pipe = Rundoc::CodeCommand::PipeRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::PipeArgs.new(pipe_cmd))
     actual = pipe.call(commands: [{command: cmd, output: out}])
 
     expected = `#{cmd} | #{pipe_cmd}`
@@ -16,7 +16,7 @@ class PipeTest < Minitest::Test
     pipe_cmd = "tail -n 2"
     cmd = "ls"
     out = `#{cmd}`
-    pipe = Rundoc::CodeCommand::PipeRunner.new(user_args: Rundoc::CodeCommand::PipeArgs.new("$ #{pipe_cmd}"))
+    pipe = Rundoc::CodeCommand::PipeRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::PipeArgs.new("$ #{pipe_cmd}"))
     actual = pipe.call(commands: [{command: cmd, output: out}])
 
     expected = `#{cmd} | #{pipe_cmd}`

--- a/test/rundoc/code_commands/print_test.rb
+++ b/test/rundoc/code_commands/print_test.rb
@@ -57,7 +57,7 @@ class PrintTest < Minitest::Test
       user_args: Rundoc::CodeCommand::PrintERBArgs.new,
       contents: %{<%= @foo = SecureRandom.hex(16) %>},
       render_command: true,
-      render_result: true,
+      render_result: true
     )
 
     assert_equal "", cmd.to_md(env)

--- a/test/rundoc/code_commands/print_test.rb
+++ b/test/rundoc/code_commands/print_test.rb
@@ -6,9 +6,7 @@ class PrintTest < Minitest::Test
     env[:before] = []
 
     input = %($ rails new myapp # Not a command since it's missing the ":::>>")
-    cmd = Rundoc::CodeCommand::PrintTextRunner.new(user_args: Rundoc::CodeCommand::PrintTextArgs.new(input))
-    cmd.render_command = false
-    cmd.render_result = true
+    cmd = Rundoc::CodeCommand::PrintTextRunner.new(user_args: Rundoc::CodeCommand::PrintTextArgs.new(input), render_command: false, render_result: true)
 
     assert_equal "", cmd.to_md(env)
     assert_equal "", cmd.call
@@ -20,9 +18,7 @@ class PrintTest < Minitest::Test
     env[:before] = []
 
     input = %($ rails new myapp # Not a command since it's missing the ":::>>")
-    cmd = Rundoc::CodeCommand::PrintTextRunner.new(user_args: Rundoc::CodeCommand::PrintTextArgs.new(input))
-    cmd.render_command = true
-    cmd.render_result = true
+    cmd = Rundoc::CodeCommand::PrintTextRunner.new(user_args: Rundoc::CodeCommand::PrintTextArgs.new(input), render_command: true, render_result: true)
 
     assert_equal "", cmd.to_md(env)
     assert_equal input, cmd.call
@@ -35,9 +31,7 @@ class PrintTest < Minitest::Test
     env[:before] = []
 
     input = %($ rails new <%= 'myapp' %> # Not a command since it's missing the ":::>>")
-    cmd = Rundoc::CodeCommand::PrintERBRunner.new(user_args: Rundoc::CodeCommand::PrintERBArgs.new(input))
-    cmd.render_command = false
-    cmd.render_result = true
+    cmd = Rundoc::CodeCommand::PrintERBRunner.new(user_args: Rundoc::CodeCommand::PrintERBArgs.new(input), render_command: false, render_result: true)
 
     assert_equal "", cmd.to_md(env)
     assert_equal "", cmd.call
@@ -49,10 +43,7 @@ class PrintTest < Minitest::Test
     env = {}
     env[:before] = []
 
-    cmd = Rundoc::CodeCommand::PrintERBRunner.new(user_args: Rundoc::CodeCommand::PrintERBArgs.new)
-    cmd.contents = %(<%= "foo" %>)
-    cmd.render_command = true
-    cmd.render_result = true
+    cmd = Rundoc::CodeCommand::PrintERBRunner.new(user_args: Rundoc::CodeCommand::PrintERBArgs.new, render_command: true, render_result: true, contents: %(<%= "foo" %>))
 
     assert_equal "", cmd.to_md(env)
     assert_equal "foo", cmd.call
@@ -62,10 +53,12 @@ class PrintTest < Minitest::Test
   def test_binding_is_preserved
     env = {}
     env[:before] = []
-    cmd = Rundoc::CodeCommand::PrintERBRunner.new(user_args: Rundoc::CodeCommand::PrintERBArgs.new)
-    cmd.contents = %{<%= @foo = SecureRandom.hex(16) %>}
-    cmd.render_command = true
-    cmd.render_result = true
+    cmd = Rundoc::CodeCommand::PrintERBRunner.new(
+      user_args: Rundoc::CodeCommand::PrintERBArgs.new,
+      contents: %{<%= @foo = SecureRandom.hex(16) %>},
+      render_command: true,
+      render_result: true,
+    )
 
     assert_equal "", cmd.to_md(env)
     assert_equal [], env[:before]
@@ -73,19 +66,13 @@ class PrintTest < Minitest::Test
 
     assert !expected.empty?
 
-    cmd = Rundoc::CodeCommand::PrintERBRunner.new(user_args: Rundoc::CodeCommand::PrintERBArgs.new)
-    cmd.contents = %(<%= @foo %>)
-    cmd.render_command = true
-    cmd.render_result = true
+    cmd = Rundoc::CodeCommand::PrintERBRunner.new(user_args: Rundoc::CodeCommand::PrintERBArgs.new, render_command: true, render_result: true, contents: %(<%= @foo %>))
 
     assert_equal "", cmd.to_md(env)
     assert_equal expected, cmd.call
     assert_equal [], env[:before]
 
-    cmd = Rundoc::CodeCommand::PrintERBRunner.new(user_args: Rundoc::CodeCommand::PrintERBArgs.new(binding: "different"))
-    cmd.contents = %(<%= @foo %>)
-    cmd.render_command = true
-    cmd.render_result = true
+    cmd = Rundoc::CodeCommand::PrintERBRunner.new(user_args: Rundoc::CodeCommand::PrintERBArgs.new(binding: "different"), render_command: true, render_result: true, contents: %(<%= @foo %>))
 
     assert_equal "", cmd.to_md(env)
     assert_equal "", cmd.call

--- a/test/rundoc/code_commands/remove_contents_test.rb
+++ b/test/rundoc/code_commands/remove_contents_test.rb
@@ -33,7 +33,7 @@ class RemoveContentsTest < Minitest::Test
         env[:fence_start] = "```ruby"
         cc.to_md(env)
 
-        assert_equal ["In file `foo.rb` remove:", Rundoc::CodeCommand::NEWLINE], env[:before]
+        assert_equal ["In file `foo.rb` remove:", Rundoc::CodeCommand::FileCommand::RemoveRunner::NEWLINE], env[:before]
       end
     end
   end

--- a/test/rundoc/code_commands/remove_contents_test.rb
+++ b/test/rundoc/code_commands/remove_contents_test.rb
@@ -21,7 +21,7 @@ class RemoveContentsTest < Minitest::Test
 
         assert_match(/sqlite3/, File.read(@file))
 
-        cc = Rundoc::CodeCommand::FileCommand::RemoveRunner.new(user_args: Rundoc::CodeCommand::FileCommand::RemoveArgs.new(@file))
+        cc = Rundoc::CodeCommand::FileCommand::RemoveRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::FileCommand::RemoveArgs.new(@file))
         cc << "gem 'sqlite3'"
         cc.call
 

--- a/test/rundoc/code_section_test.rb
+++ b/test/rundoc/code_section_test.rb
@@ -61,8 +61,8 @@ class CodeSectionTest < Minitest::Test
     code_section.render
 
     code_command = code_section.executed_commands.first
-    assert_equal true, code_command.render_command
-    assert_equal false, code_command.render_result
+    assert_equal true, code_command.render_command?
+    assert_equal false, code_command.render_result?
 
     contents = <<~RUBY
       ```
@@ -80,8 +80,8 @@ class CodeSectionTest < Minitest::Test
     code_section.render
 
     code_command = code_section.executed_commands.first
-    assert_equal true, code_command.render_command
-    assert_equal false, code_command.render_result
+    assert_equal true, code_command.render_command?
+    assert_equal false, code_command.render_result?
   end
 
   def test_show_command_show_render
@@ -102,8 +102,8 @@ class CodeSectionTest < Minitest::Test
 
     puts code_section.executed_commands.inspect
     code_command = code_section.executed_commands.first
-    assert_equal true, code_command.render_command
-    assert_equal true, code_command.render_result
+    assert_equal true, code_command.render_command?
+    assert_equal true, code_command.render_result?
   end
 
   def test_hide_command_hide_render
@@ -123,8 +123,8 @@ class CodeSectionTest < Minitest::Test
     code_section.render
 
     code_command = code_section.executed_commands.first
-    assert_equal false, code_command.render_command
-    assert_equal false, code_command.render_result
+    assert_equal false, code_command.render_command?
+    assert_equal false, code_command.render_result?
 
     contents = <<~RUBY
       ```
@@ -142,8 +142,8 @@ class CodeSectionTest < Minitest::Test
     code_section.render
 
     code_command = code_section.executed_commands.first
-    assert_equal false, code_command.render_command
-    assert_equal false, code_command.render_result
+    assert_equal false, code_command.render_command?
+    assert_equal false, code_command.render_result?
   end
 
   def test_hide_command_show_render
@@ -163,7 +163,7 @@ class CodeSectionTest < Minitest::Test
     code_section.render
 
     code_command = code_section.executed_commands.first
-    assert_equal false, code_command.render_command
-    assert_equal true, code_command.render_result
+    assert_equal false, code_command.render_command?
+    assert_equal true, code_command.render_result?
   end
 end


### PR DESCRIPTION
Now that Deferred owns `keyword` and `original_args`, CodeCommand's interface can be simplified. This cleans up the constructor signature so that adding `io:` as a required kwarg in the next PR is straightforward instead of fighting with attr_writers and optional args.

Stack: 2/4 — #110 → this → #113 → #114