### PR TITLE
Inject io: dependency into CodeCommand runners

### DIFF
--- a/lib/rundoc/cli.rb
+++ b/lib/rundoc/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   class CLI
     module DEFAULTS

--- a/lib/rundoc/cli.rb
+++ b/lib/rundoc/cli.rb
@@ -159,7 +159,8 @@ module Rundoc
       Dir.chdir(execution_context.output_dir) do
         parser = Rundoc::Document.new(
           source_contents,
-          context: execution_context
+          context: execution_context,
+          io: io
         )
         output = begin
           parser.to_md

--- a/lib/rundoc/code_command.rb
+++ b/lib/rundoc/code_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   # Generic CodeCommand class to be inherited
   #
@@ -30,7 +32,7 @@ module Rundoc
     end
 
     def push(contents)
-      @contents ||= ""
+      @contents ||= +""
       @contents << contents
     end
     alias_method :<<, :push

--- a/lib/rundoc/code_command.rb
+++ b/lib/rundoc/code_command.rb
@@ -4,7 +4,10 @@ module Rundoc
   class CodeCommand
     attr_accessor :contents
 
-    def initialize(render_command:, render_result:, contents: nil)
+    attr_reader :io
+
+    def initialize(render_command:, render_result:, io:, contents: nil)
+      @io = io
       @render_command = render_command
       @render_result = render_result
       push(contents) if contents && !contents.empty?

--- a/lib/rundoc/code_command/background.rb
+++ b/lib/rundoc/code_command/background.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::Background
 end
 

--- a/lib/rundoc/code_command/background/log/clear.rb
+++ b/lib/rundoc/code_command/background/log/clear.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::Background::Log
   class ClearArgs
     attr_reader :name

--- a/lib/rundoc/code_command/background/log/read.rb
+++ b/lib/rundoc/code_command/background/log/read.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::Background::Log
   class ReadArgs
     attr_reader :name

--- a/lib/rundoc/code_command/background/process_spawn.rb
+++ b/lib/rundoc/code_command/background/process_spawn.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "shellwords"
 require "timeout"
 require "fileutils"

--- a/lib/rundoc/code_command/background/process_spawn.rb
+++ b/lib/rundoc/code_command/background/process_spawn.rb
@@ -126,7 +126,7 @@ class Rundoc::CodeCommand::Background
       Process.kill("TERM", -Process.getpgid(@pid))
       Process.wait(@pid)
     rescue Errno::ESRCH => e
-      puts "Error stopping process (command: #{command}): #{e}"
+      warn "Error stopping process (command: #{command}): #{e}"
     ensure
       print_io&.puts "Log contents for `#{command}`:\n#{@log.read}"
     end

--- a/lib/rundoc/code_command/background/process_spawn.rb
+++ b/lib/rundoc/code_command/background/process_spawn.rb
@@ -128,7 +128,7 @@ class Rundoc::CodeCommand::Background
       Process.kill("TERM", -Process.getpgid(@pid))
       Process.wait(@pid)
     rescue Errno::ESRCH => e
-      warn "Error stopping process (command: #{command}): #{e}"
+      print_io&.puts "Error stopping process (command: #{command}): #{e}"
     ensure
       print_io&.puts "Log contents for `#{command}`:\n#{@log.read}"
     end

--- a/lib/rundoc/code_command/background/start.rb
+++ b/lib/rundoc/code_command/background/start.rb
@@ -37,7 +37,7 @@ class Rundoc::CodeCommand::Background
         log: @log,
         out: @redirect
       ).tap do |spawn|
-        puts "Spawning commmand: `#{spawn.command}`"
+        io.puts "Spawning commmand: `#{spawn.command}`"
         ProcessSpawn.add(@name, spawn)
       end
     end

--- a/lib/rundoc/code_command/background/start.rb
+++ b/lib/rundoc/code_command/background/start.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "tempfile"
 
 class Rundoc::CodeCommand::Background

--- a/lib/rundoc/code_command/background/stdin_write.rb
+++ b/lib/rundoc/code_command/background/stdin_write.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::Background
   class StdinWriteArgs
     attr_reader :contents, :name, :wait, :timeout, :ending

--- a/lib/rundoc/code_command/background/stop.rb
+++ b/lib/rundoc/code_command/background/stop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::Background
   class StopArgs
     attr_reader :name

--- a/lib/rundoc/code_command/background/wait.rb
+++ b/lib/rundoc/code_command/background/wait.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::Background
   class WaitArgs
     attr_reader :name, :wait, :timeout

--- a/lib/rundoc/code_command/bash.rb
+++ b/lib/rundoc/code_command/bash.rb
@@ -44,16 +44,16 @@ class Rundoc::CodeCommand::BashRunner < Rundoc::CodeCommand
     cmd = "(#{cmd}) 2>&1"
     msg = "Running: $ '#{cmd}'"
     msg << " with stdin: '#{stdin.inspect}'" if stdin && !stdin.empty?
-    puts msg
+    io.puts msg
 
     result = ""
-    IO.popen(cmd, "w+") do |io|
-      io << stdin if stdin
-      io.close_write
+    IO.popen(cmd, "w+") do |pipe|
+      pipe << stdin if stdin
+      pipe.close_write
 
-      until io.eof?
-        buffer = io.gets
-        puts "    #{buffer}"
+      until pipe.eof?
+        buffer = pipe.gets
+        io.puts "    #{buffer}"
 
         result << sanitize_escape_chars(buffer)
       end

--- a/lib/rundoc/code_command/bash.rb
+++ b/lib/rundoc/code_command/bash.rb
@@ -8,15 +8,14 @@ end
 
 class Rundoc::CodeCommand::BashRunner < Rundoc::CodeCommand
   def initialize(user_args:, **)
+    super(**)
     @line = user_args.line
-    @contents = ""
     @delegate = case @line.split(" ").first.downcase
     when "cd"
-      Cd.new(@line)
+      Cd.new(@line, io: io)
     else
       false
     end
-    super(**)
   end
 
   # predicate to over-write for failure support

--- a/lib/rundoc/code_command/bash.rb
+++ b/lib/rundoc/code_command/bash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::BashArgs
   attr_reader :line
 
@@ -42,11 +44,11 @@ class Rundoc::CodeCommand::BashRunner < Rundoc::CodeCommand
 
   def shell(cmd, stdin = nil)
     cmd = "(#{cmd}) 2>&1"
-    msg = "Running: $ '#{cmd}'"
+    msg = +"Running: $ '#{cmd}'"
     msg << " with stdin: '#{stdin.inspect}'" if stdin && !stdin.empty?
     io.puts msg
 
-    result = ""
+    result = +""
     IO.popen(cmd, "w+") do |pipe|
       pipe << stdin if stdin
       pipe.close_write

--- a/lib/rundoc/code_command/bash/cd.rb
+++ b/lib/rundoc/code_command/bash/cd.rb
@@ -1,6 +1,7 @@
 class Rundoc::CodeCommand::BashRunner
   class Cd < Rundoc::CodeCommand::BashRunner
-    def initialize(line)
+    def initialize(line, io: $stdout)
+      @io = io
       @line = line
     end
 

--- a/lib/rundoc/code_command/bash/cd.rb
+++ b/lib/rundoc/code_command/bash/cd.rb
@@ -21,7 +21,7 @@ class Rundoc::CodeCommand::BashRunner
 
     def call(env)
       line = @line.sub("cd", "").strip
-      puts "running $ cd #{line}"
+      @io.puts "running $ cd #{line}"
 
       supress_chdir_warning do
         Dir.chdir(line)

--- a/lib/rundoc/code_command/bash/cd.rb
+++ b/lib/rundoc/code_command/bash/cd.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::BashRunner
   class Cd < Rundoc::CodeCommand::BashRunner
     def initialize(line, io: $stdout)

--- a/lib/rundoc/code_command/deferred.rb
+++ b/lib/rundoc/code_command/deferred.rb
@@ -36,12 +36,13 @@ module Rundoc
       end
       alias_method :<<, :push
 
-      def build
+      def build(io: $stdout)
         @built ||= @runner_klass.new(
           user_args: @args_instance,
           render_command: render_command,
           render_result: render_result,
-          contents: @contents
+          contents: @contents,
+          io: io
         )
       rescue UnknownCommand
         raise "No such command registered with rundoc #{keyword.inspect} for `#{keyword} #{original_args}`"

--- a/lib/rundoc/code_command/deferred.rb
+++ b/lib/rundoc/code_command/deferred.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   class CodeCommand
     # Hold enough information to construct commands, but don't yet
@@ -31,7 +33,7 @@ module Rundoc
       end
 
       def push(contents)
-        @contents ||= ""
+        @contents ||= +""
         @contents << contents
       end
       alias_method :<<, :push

--- a/lib/rundoc/code_command/file_command/append.rb
+++ b/lib/rundoc/code_command/file_command/append.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::FileCommand
   class AppendArgs
     attr_reader :filename
@@ -43,7 +45,7 @@ class Rundoc::CodeCommand::FileCommand
     end
 
     def concat_with_newline(str1, str2)
-      result = ""
+      result = +""
       result << str1
       result << "\n" unless ends_in_newline?(result)
       result << str2

--- a/lib/rundoc/code_command/file_command/append.rb
+++ b/lib/rundoc/code_command/file_command/append.rb
@@ -70,10 +70,10 @@ class Rundoc::CodeCommand::FileCommand
       mkdir_p
       doc = File.read(filename)
       if @line_number
-        puts "Writing to: '#{filename}' line #{@line_number} with: #{contents.inspect}"
+        io.puts "Writing to: '#{filename}' line #{@line_number} with: #{contents.inspect}"
         doc = insert_contents_into_at_line(doc)
       else
-        puts "Appending to file: '#{filename}' with: #{contents.inspect}"
+        io.puts "Appending to file: '#{filename}' with: #{contents.inspect}"
         doc = concat_with_newline(doc, contents)
       end
 

--- a/lib/rundoc/code_command/file_command/remove.rb
+++ b/lib/rundoc/code_command/file_command/remove.rb
@@ -36,7 +36,7 @@ class Rundoc::CodeCommand::FileCommand
     end
 
     def call(env = {})
-      puts "Deleting '#{contents.strip}' from #{filename}"
+      io.puts "Deleting '#{contents.strip}' from #{filename}"
       raise "#{filename} does not exist" unless File.exist?(filename)
 
       regex = /^\s*#{Regexp.quote(contents)}/

--- a/lib/rundoc/code_command/file_command/remove.rb
+++ b/lib/rundoc/code_command/file_command/remove.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::FileCommand
   class RemoveArgs
     attr_reader :filename

--- a/lib/rundoc/code_command/no_such_command.rb
+++ b/lib/rundoc/code_command/no_such_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   class CodeCommand
     class NoSuchCommand < Rundoc::CodeCommand

--- a/lib/rundoc/code_command/pipe.rb
+++ b/lib/rundoc/code_command/pipe.rb
@@ -10,8 +10,8 @@ module Rundoc
 
     class PipeRunner < Rundoc::CodeCommand
       def initialize(user_args:, **)
-        @delegate = parse(user_args.line)
         super(**)
+        @delegate = parse(user_args.line)
       end
 
       # before: "",
@@ -20,7 +20,7 @@ module Rundoc
       #   [[cmd, output], [cmd, output]]
       def call(env = {})
         last_command = env[:commands].last
-        puts "Piping: results of '#{last_command[:command]}' to '#{@delegate}'"
+        io.puts "Piping: results of '#{last_command[:command]}' to '#{@delegate}'"
 
         @delegate.push(last_command[:output])
         @delegate.call(env)

--- a/lib/rundoc/code_command/pipe.rb
+++ b/lib/rundoc/code_command/pipe.rb
@@ -39,14 +39,14 @@ module Rundoc
 
         # Unregistered keywords (e.g. `| tail -n 2`) aren't rundoc commands — treat them as bash
         if actual.runner_klass == Rundoc::CodeCommand::NoSuchCommand
-          actual = Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new(code), render_command: false, render_result: false)
+          actual = Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new(code), render_command: false, render_result: false, io: io)
         end
         actual
 
       # Since `| tail -n 2` does not start with a `$` assume any "naked" commands
       # are bash
       rescue Parslet::ParseFailed
-        Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new(code), render_command: false, render_result: false)
+        Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new(code), render_command: false, render_result: false, io: io)
       end
     end
   end

--- a/lib/rundoc/code_command/pipe.rb
+++ b/lib/rundoc/code_command/pipe.rb
@@ -41,9 +41,10 @@ module Rundoc
 
         # Unregistered keywords (e.g. `| tail -n 2`) aren't rundoc commands — treat them as bash
         if actual.runner_klass == Rundoc::CodeCommand::NoSuchCommand
-          actual = Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new(code), render_command: false, render_result: false, io: io)
+          Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new(code), render_command: false, render_result: false, io: io)
+        else
+          actual.build(io: io)
         end
-        actual
 
       # Since `| tail -n 2` does not start with a `$` assume any "naked" commands
       # are bash

--- a/lib/rundoc/code_command/pipe.rb
+++ b/lib/rundoc/code_command/pipe.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   class CodeCommand
     class PipeArgs

--- a/lib/rundoc/code_command/pre/erb.rb
+++ b/lib/rundoc/code_command/pre/erb.rb
@@ -10,7 +10,7 @@ class Rundoc::CodeCommand
   end
 
   class PreErbRunner < Rundoc::CodeCommand
-    def initialize(user_args:, render_command:, render_result:, contents: nil)
+    def initialize(user_args:, render_command:, render_result:, **)
       @line = user_args.line
       @binding = RUNDOC_ERB_BINDINGS[RUNDOC_DEFAULT_ERB_BINDING]
       @code = nil
@@ -18,9 +18,7 @@ class Rundoc::CodeCommand
       @template = nil
       @render_delegate_result = render_result
       @render_delegate_command = render_command
-      @render_result = false
-      @render_command = false
-      push(contents) if contents && !contents.empty?
+      super(render_command: false, render_result: false, **)
     end
 
     def code

--- a/lib/rundoc/code_command/pre/erb.rb
+++ b/lib/rundoc/code_command/pre/erb.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../print/erb"
 
 class Rundoc::CodeCommand

--- a/lib/rundoc/code_command/pre/erb.rb
+++ b/lib/rundoc/code_command/pre/erb.rb
@@ -32,10 +32,10 @@ class Rundoc::CodeCommand
           .join("\n")
         @template = ":::#{vis} #{code}"
 
-        puts "pre.erb: Applying ERB, template:\n#{@template}"
+        io.puts "pre.erb: Applying ERB, template:\n#{@template}"
         result = ERB.new(@template).result(@binding)
-        puts "pre.erb: ERB result:\n#{result}"
-        puts "pre.erb: done, ready to delegate"
+        io.puts "pre.erb: ERB result:\n#{result}"
+        io.puts "pre.erb: done, ready to delegate"
         result
       end
     end

--- a/lib/rundoc/code_command/print/erb.rb
+++ b/lib/rundoc/code_command/print/erb.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "erb"
 
 class EmptyBinding

--- a/lib/rundoc/code_command/print/text.rb
+++ b/lib/rundoc/code_command/print/text.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand
   class PrintTextArgs
     attr_reader :line

--- a/lib/rundoc/code_command/raw.rb
+++ b/lib/rundoc/code_command/raw.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   class CodeCommand
     class Raw < CodeCommand

--- a/lib/rundoc/code_command/rundoc/require.rb
+++ b/lib/rundoc/code_command/rundoc/require.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ::Rundoc::CodeCommand
   class RundocCommand
     class RequireArgs

--- a/lib/rundoc/code_command/rundoc/require.rb
+++ b/lib/rundoc/code_command/rundoc/require.rb
@@ -30,7 +30,8 @@ class ::Rundoc::CodeCommand
             output_dir: execution_context.output_dir,
             screenshots_dirname: execution_context.screenshots_dir,
             with_contents_dir: execution_context.with_contents_dir
-          )
+          ),
+          io: io
         ).to_md
 
         if render_result?

--- a/lib/rundoc/code_command/rundoc/require.rb
+++ b/lib/rundoc/code_command/rundoc/require.rb
@@ -35,10 +35,10 @@ class ::Rundoc::CodeCommand
         ).to_md
 
         if render_result?
-          puts "rundoc.require: Done executing #{@path.to_s.inspect}, putting contents into document"
+          io.puts "rundoc.require: Done executing #{@path.to_s.inspect}, putting contents into document"
           env[:before] << output
         else
-          puts "rundoc.require: Done executing #{@path.to_s.inspect}, quietly"
+          io.puts "rundoc.require: Done executing #{@path.to_s.inspect}, quietly"
         end
 
         ""

--- a/lib/rundoc/code_command/rundoc_command.rb
+++ b/lib/rundoc/code_command/rundoc_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ::Rundoc
   class CodeCommand
     class RundocCommandArgs

--- a/lib/rundoc/code_command/rundoc_command.rb
+++ b/lib/rundoc/code_command/rundoc_command.rb
@@ -19,7 +19,7 @@ module ::Rundoc
       end
 
       def call(env = {})
-        puts "Running: #{contents}"
+        io.puts "Running: #{contents}"
         eval(contents) # rubocop:disable Security/Eval
         ""
       end

--- a/lib/rundoc/code_command/website.rb
+++ b/lib/rundoc/code_command/website.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::Website
 end
 

--- a/lib/rundoc/code_command/website/driver.rb
+++ b/lib/rundoc/code_command/website/driver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "capybara"
 
 Capybara::Selenium::Driver.load_selenium

--- a/lib/rundoc/code_command/website/navigate.rb
+++ b/lib/rundoc/code_command/website/navigate.rb
@@ -23,7 +23,7 @@ class Rundoc::CodeCommand::Website
     end
 
     def call(env = {})
-      puts "website.navigate [#{@name}]: #{contents}"
+      io.puts "website.navigate [#{@name}]: #{contents}"
       driver.safe_eval(contents, env)
       ""
     end

--- a/lib/rundoc/code_command/website/navigate.rb
+++ b/lib/rundoc/code_command/website/navigate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::Website
   class NavigateArgs
     attr_reader :name

--- a/lib/rundoc/code_command/website/screenshot.rb
+++ b/lib/rundoc/code_command/website/screenshot.rb
@@ -25,7 +25,7 @@ class Rundoc::CodeCommand::Website
     end
 
     def call(env = {})
-      puts "Taking screenshot: #{driver.current_url}"
+      io.puts "Taking screenshot: #{driver.current_url}"
       filename = driver.screenshot(
         upload: @upload,
         screenshots_dir: env[:context].screenshots_dir

--- a/lib/rundoc/code_command/website/screenshot.rb
+++ b/lib/rundoc/code_command/website/screenshot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::Website
   class ScreenshotArgs
     attr_reader :name, :upload

--- a/lib/rundoc/code_command/website/visit.rb
+++ b/lib/rundoc/code_command/website/visit.rb
@@ -44,7 +44,7 @@ class Rundoc::CodeCommand::Website
     end
 
     def call(env = {})
-      message = "Visting: #{@url}"
+      message = +"Visting: #{@url}"
       message << "and executing:\n#{contents}" unless contents.nil? || contents.empty?
 
       io.puts message

--- a/lib/rundoc/code_command/website/visit.rb
+++ b/lib/rundoc/code_command/website/visit.rb
@@ -47,7 +47,7 @@ class Rundoc::CodeCommand::Website
       message = "Visting: #{@url}"
       message << "and executing:\n#{contents}" unless contents.nil? || contents.empty?
 
-      puts message
+      io.puts message
 
       driver.visit(@url, max_attempts: @max_attempts) if @url
       driver.scroll(@scroll) if @scroll

--- a/lib/rundoc/code_command/website/visit.rb
+++ b/lib/rundoc/code_command/website/visit.rb
@@ -33,7 +33,8 @@ class Rundoc::CodeCommand::Website
         url: @url,
         height: @height,
         width: @width,
-        visible: @visible
+        visible: @visible,
+        io: io
       ).tap do |driver|
         Driver.add(@name, driver)
       end

--- a/lib/rundoc/code_command/write.rb
+++ b/lib/rundoc/code_command/write.rb
@@ -54,7 +54,7 @@ module Rundoc
       end
 
       def call(env = {})
-        puts "Writing to: '#{filename}'"
+        io.puts "Writing to: '#{filename}'"
         mkdir_p
         File.write(filename, contents)
         contents

--- a/lib/rundoc/code_command/write.rb
+++ b/lib/rundoc/code_command/write.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   class CodeCommand
     module FileUtil

--- a/lib/rundoc/context/after_build.rb
+++ b/lib/rundoc/context/after_build.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   module Context
     # Public interface for the `Rundoc.after_build` proc

--- a/lib/rundoc/context/execution.rb
+++ b/lib/rundoc/context/execution.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   module Context
     # Holds configuration for the currently executing script

--- a/lib/rundoc/document.rb
+++ b/lib/rundoc/document.rb
@@ -11,7 +11,8 @@ module Rundoc
 
     attr_reader :contents, :stack, :context
 
-    def initialize(contents, context:)
+    def initialize(contents, context:, io: $stdout)
+      @io = io
       @context = context
       @contents = contents
       @original = contents.dup
@@ -59,7 +60,8 @@ module Rundoc
             fence: match[:fence],
             lang: match[:lang],
             code: match[:contents],
-            context: context
+            context: context,
+            io: @io
           )
         end
         @contents = tail

--- a/lib/rundoc/document.rb
+++ b/lib/rundoc/document.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   # Represents a single rundoc file on disk,
   #

--- a/lib/rundoc/fenced_code_block.rb
+++ b/lib/rundoc/fenced_code_block.rb
@@ -24,7 +24,8 @@ module Rundoc
     # @param code [String] the code block contents inside the fence.
     # @param context [Context::Execution] The details about where
     #        the code block came from.
-    def initialize(fence:, lang:, code:, context:)
+    def initialize(fence:, lang:, code:, context:, io: $stdout)
+      @io = io
       @fence = fence
       @lang = lang
       @code = code
@@ -57,7 +58,7 @@ module Rundoc
 
       while (item = @stack.pop)
         code_command = if item.is_a?(CodeCommand::Deferred)
-          item.build
+          item.build(io: @io)
         else
           item
         end

--- a/lib/rundoc/peg_parser.rb
+++ b/lib/rundoc/peg_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "parslet"
 
 module Rundoc

--- a/lib/rundoc/version.rb
+++ b/lib/rundoc/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   VERSION = "4.1.4"
 end

--- a/test/rundoc/code_commands/append_file_test.rb
+++ b/test/rundoc/code_commands/append_file_test.rb
@@ -7,7 +7,7 @@ class AppendFileTest < Minitest::Test
         file = "foo.rb"
         `echo 'foo' >> #{file}`
 
-        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file))
+        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file))
         cc << "bar"
         cc.call
 
@@ -16,7 +16,7 @@ class AppendFileTest < Minitest::Test
         assert_match(/foo/, result)
         assert_match(/bar/, result)
 
-        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file))
+        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file))
         cc << "baz"
         cc.call
 
@@ -39,7 +39,7 @@ class AppendFileTest < Minitest::Test
         line = 2
         `echo '#{contents}' >> #{file}`
 
-        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("#{file}##{line}"))
+        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("#{file}##{line}"))
         cc << "gem 'pg'"
         cc.call
 
@@ -54,7 +54,7 @@ class AppendFileTest < Minitest::Test
       Dir.chdir(dir) do
         filename = "file-#{Time.now.utc.strftime("%Y%m%d%H%M%S")}.txt"
         FileUtils.touch(filename)
-        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("file-*.txt"))
+        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("file-*.txt"))
         cc << "some text"
         cc.call
 
@@ -69,7 +69,7 @@ class AppendFileTest < Minitest::Test
         FileUtils.touch("file-1234.txt")
         FileUtils.touch("file-5678.txt")
         assert_raises do
-          cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("file-*.txt"))
+          cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("file-*.txt"))
           cc << "some text"
           cc.call
         end

--- a/test/rundoc/code_commands/background_test.rb
+++ b/test/rundoc/code_commands/background_test.rb
@@ -6,33 +6,33 @@ class BackgroundTest < Minitest::Test
       Dir.chdir(dir) do
         # Intentionally out of order, should not raise an error as long as "cat"
         # command exists at execution time
-        stdin_write = Rundoc::CodeCommand::Background::StdinWriteRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::StdinWriteArgs.new(
+        stdin_write = Rundoc::CodeCommand::Background::StdinWriteRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::Background::StdinWriteArgs.new(
           "hello there",
           name: "cat",
           wait: "hello"
         ))
 
-        background_start = Rundoc::CodeCommand::Background::StartRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::StartArgs.new("cat",
+        background_start = Rundoc::CodeCommand::Background::StartRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::Background::StartArgs.new("cat",
           name: "cat"))
 
         background_start.call
         output = stdin_write.call
         assert_equal("hello there" + $/, output)
 
-        Rundoc::CodeCommand::Background::WaitRunner.new(render_command: false, render_result: false,
+        Rundoc::CodeCommand::Background::WaitRunner.new(render_command: false, render_result: false, io: StringIO.new,
           user_args: Rundoc::CodeCommand::Background::WaitArgs.new(
             name: "cat",
             wait: "hello"
           )
         ).call
 
-        Rundoc::CodeCommand::Background::Log::ClearRunner.new(render_command: false, render_result: false,
+        Rundoc::CodeCommand::Background::Log::ClearRunner.new(render_command: false, render_result: false, io: StringIO.new,
           user_args: Rundoc::CodeCommand::Background::Log::ClearArgs.new(
             name: "cat"
           )
         ).call
 
-        output = Rundoc::CodeCommand::Background::StdinWriteRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::StdinWriteArgs.new(
+        output = Rundoc::CodeCommand::Background::StdinWriteRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::Background::StdinWriteArgs.new(
           "general kenobi",
           name: "cat",
           wait: "general"
@@ -48,7 +48,7 @@ class BackgroundTest < Minitest::Test
         file = "foo.txt"
         run!("echo 'foo' >> #{file}")
 
-        background_start = Rundoc::CodeCommand::Background::StartRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::StartArgs.new("tail -f #{file}",
+        background_start = Rundoc::CodeCommand::Background::StartRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::Background::StartArgs.new("tail -f #{file}",
           name: "tail2",
           wait: "f"))
 
@@ -59,7 +59,7 @@ class BackgroundTest < Minitest::Test
         assert_match("foo", output)
         assert_equal(true, background_start.alive?)
 
-        background_stop = Rundoc::CodeCommand::Background::StopRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::StopArgs.new(name: "tail2"))
+        background_stop = Rundoc::CodeCommand::Background::StopRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::Background::StopArgs.new(name: "tail2"))
         background_stop.call
 
         assert_equal(false, background_start.alive?)
@@ -73,7 +73,7 @@ class BackgroundTest < Minitest::Test
         file = "foo.txt"
         run!("echo 'foo' >> #{file}")
 
-        background_start = Rundoc::CodeCommand::Background::StartRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::StartArgs.new("tail -f #{file}",
+        background_start = Rundoc::CodeCommand::Background::StartRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::Background::StartArgs.new("tail -f #{file}",
           name: "tail",
           wait: "f"))
         output = background_start.call
@@ -81,12 +81,12 @@ class BackgroundTest < Minitest::Test
         assert_match("foo", output)
         assert_equal(true, background_start.alive?)
 
-        log_read = Rundoc::CodeCommand::Background::Log::ReadRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::Log::ReadArgs.new(name: "tail"))
+        log_read = Rundoc::CodeCommand::Background::Log::ReadRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::Background::Log::ReadArgs.new(name: "tail"))
         output = log_read.call
 
         assert_equal("foo", output.chomp)
 
-        log_clear = Rundoc::CodeCommand::Background::Log::ClearRunner.new(render_command: false, render_result: false,user_args: Rundoc::CodeCommand::Background::Log::ClearArgs.new(name: "tail"))
+        log_clear = Rundoc::CodeCommand::Background::Log::ClearRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::Background::Log::ClearArgs.new(name: "tail"))
         output = log_clear.call
         assert_equal("", output)
 
@@ -94,12 +94,12 @@ class BackgroundTest < Minitest::Test
 
         background_start.background.wait("bar")
 
-        log_read = Rundoc::CodeCommand::Background::Log::ReadRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::Log::ReadArgs.new(name: "tail"))
+        log_read = Rundoc::CodeCommand::Background::Log::ReadRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::Background::Log::ReadArgs.new(name: "tail"))
         output = log_read.call
 
         assert_equal("bar", output.chomp)
 
-        background_stop = Rundoc::CodeCommand::Background::StopRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::Background::StopArgs.new(name: "tail"))
+        background_stop = Rundoc::CodeCommand::Background::StopRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::Background::StopArgs.new(name: "tail"))
         background_stop.call
 
         assert_equal(false, background_start.alive?)

--- a/test/rundoc/code_commands/bash_test.rb
+++ b/test/rundoc/code_commands/bash_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class BashTest < Minitest::Test
   def test_bash_returns_cd
     original_dir = `pwd`
-    Rundoc::CodeCommand::BashRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::BashArgs.new("cd ..")).call
+    Rundoc::CodeCommand::BashRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::BashArgs.new("cd ..")).call
     now_dir = `pwd`
     refute_equal original_dir, now_dir
   ensure
@@ -12,14 +12,14 @@ class BashTest < Minitest::Test
 
   def test_bash_stderr_with_or_is_capture
     command = "1>&2 echo 'msg to STDERR 1' || 1>&2 echo 'msg to STDERR 2'"
-    bash = Rundoc::CodeCommand::BashRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::BashArgs.new(command))
+    bash = Rundoc::CodeCommand::BashRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::BashArgs.new(command))
     assert_equal "$ #{command}", bash.to_md
     assert_equal "msg to STDERR 1\n", bash.call
   end
 
   def test_bash_shells_and_shows_correctly
     ["pwd", "ls"].each do |command|
-      bash = Rundoc::CodeCommand::BashRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::BashArgs.new(command))
+      bash = Rundoc::CodeCommand::BashRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::BashArgs.new(command))
       assert_equal "$ #{command}", bash.to_md
       assert_equal `#{command}`, bash.call
     end
@@ -27,7 +27,7 @@ class BashTest < Minitest::Test
 
   def test_stdin
     command = "tail -n 2"
-    bash = Rundoc::CodeCommand::BashRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::BashArgs.new(command))
+    bash = Rundoc::CodeCommand::BashRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::BashArgs.new(command))
     bash << "foo\nbar\nbaz\n"
     assert_equal "bar\nbaz\n", bash.call
   end

--- a/test/rundoc/code_commands/pipe_test.rb
+++ b/test/rundoc/code_commands/pipe_test.rb
@@ -5,7 +5,7 @@ class PipeTest < Minitest::Test
     pipe_cmd = "tail -n 2"
     cmd = "ls"
     out = `#{cmd}`
-    pipe = Rundoc::CodeCommand::PipeRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::PipeArgs.new(pipe_cmd))
+    pipe = Rundoc::CodeCommand::PipeRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::PipeArgs.new(pipe_cmd))
     actual = pipe.call(commands: [{command: cmd, output: out}])
 
     expected = `#{cmd} | #{pipe_cmd}`
@@ -16,7 +16,7 @@ class PipeTest < Minitest::Test
     pipe_cmd = "tail -n 2"
     cmd = "ls"
     out = `#{cmd}`
-    pipe = Rundoc::CodeCommand::PipeRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::PipeArgs.new("$ #{pipe_cmd}"))
+    pipe = Rundoc::CodeCommand::PipeRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::PipeArgs.new("$ #{pipe_cmd}"))
     actual = pipe.call(commands: [{command: cmd, output: out}])
 
     expected = `#{cmd} | #{pipe_cmd}`

--- a/test/rundoc/code_commands/print_test.rb
+++ b/test/rundoc/code_commands/print_test.rb
@@ -6,7 +6,7 @@ class PrintTest < Minitest::Test
     env[:before] = []
 
     input = %($ rails new myapp # Not a command since it's missing the ":::>>")
-    cmd = Rundoc::CodeCommand::PrintTextRunner.new(user_args: Rundoc::CodeCommand::PrintTextArgs.new(input), render_command: false, render_result: true)
+    cmd = Rundoc::CodeCommand::PrintTextRunner.new(user_args: Rundoc::CodeCommand::PrintTextArgs.new(input), io: StringIO.new, render_command: false, render_result: true)
 
     assert_equal "", cmd.to_md(env)
     assert_equal "", cmd.call
@@ -18,7 +18,7 @@ class PrintTest < Minitest::Test
     env[:before] = []
 
     input = %($ rails new myapp # Not a command since it's missing the ":::>>")
-    cmd = Rundoc::CodeCommand::PrintTextRunner.new(user_args: Rundoc::CodeCommand::PrintTextArgs.new(input), render_command: true, render_result: true)
+    cmd = Rundoc::CodeCommand::PrintTextRunner.new(user_args: Rundoc::CodeCommand::PrintTextArgs.new(input), io: StringIO.new, render_command: true, render_result: true)
 
     assert_equal "", cmd.to_md(env)
     assert_equal input, cmd.call
@@ -31,7 +31,7 @@ class PrintTest < Minitest::Test
     env[:before] = []
 
     input = %($ rails new <%= 'myapp' %> # Not a command since it's missing the ":::>>")
-    cmd = Rundoc::CodeCommand::PrintERBRunner.new(user_args: Rundoc::CodeCommand::PrintERBArgs.new(input), render_command: false, render_result: true)
+    cmd = Rundoc::CodeCommand::PrintERBRunner.new(user_args: Rundoc::CodeCommand::PrintERBArgs.new(input), io: StringIO.new, render_command: false, render_result: true)
 
     assert_equal "", cmd.to_md(env)
     assert_equal "", cmd.call
@@ -43,7 +43,7 @@ class PrintTest < Minitest::Test
     env = {}
     env[:before] = []
 
-    cmd = Rundoc::CodeCommand::PrintERBRunner.new(user_args: Rundoc::CodeCommand::PrintERBArgs.new, render_command: true, render_result: true, contents: %(<%= "foo" %>))
+    cmd = Rundoc::CodeCommand::PrintERBRunner.new(user_args: Rundoc::CodeCommand::PrintERBArgs.new, io: StringIO.new, render_command: true, render_result: true, contents: %(<%= "foo" %>))
 
     assert_equal "", cmd.to_md(env)
     assert_equal "foo", cmd.call
@@ -55,6 +55,7 @@ class PrintTest < Minitest::Test
     env[:before] = []
     cmd = Rundoc::CodeCommand::PrintERBRunner.new(
       user_args: Rundoc::CodeCommand::PrintERBArgs.new,
+      io: StringIO.new,
       contents: %{<%= @foo = SecureRandom.hex(16) %>},
       render_command: true,
       render_result: true,
@@ -66,13 +67,13 @@ class PrintTest < Minitest::Test
 
     assert !expected.empty?
 
-    cmd = Rundoc::CodeCommand::PrintERBRunner.new(user_args: Rundoc::CodeCommand::PrintERBArgs.new, render_command: true, render_result: true, contents: %(<%= @foo %>))
+    cmd = Rundoc::CodeCommand::PrintERBRunner.new(user_args: Rundoc::CodeCommand::PrintERBArgs.new, io: StringIO.new, render_command: true, render_result: true, contents: %(<%= @foo %>))
 
     assert_equal "", cmd.to_md(env)
     assert_equal expected, cmd.call
     assert_equal [], env[:before]
 
-    cmd = Rundoc::CodeCommand::PrintERBRunner.new(user_args: Rundoc::CodeCommand::PrintERBArgs.new(binding: "different"), render_command: true, render_result: true, contents: %(<%= @foo %>))
+    cmd = Rundoc::CodeCommand::PrintERBRunner.new(user_args: Rundoc::CodeCommand::PrintERBArgs.new(binding: "different"), io: StringIO.new, render_command: true, render_result: true, contents: %(<%= @foo %>))
 
     assert_equal "", cmd.to_md(env)
     assert_equal "", cmd.call

--- a/test/rundoc/code_commands/remove_contents_test.rb
+++ b/test/rundoc/code_commands/remove_contents_test.rb
@@ -21,7 +21,7 @@ class RemoveContentsTest < Minitest::Test
 
         assert_match(/sqlite3/, File.read(@file))
 
-        cc = Rundoc::CodeCommand::FileCommand::RemoveRunner.new(render_command: false, render_result: false, user_args: Rundoc::CodeCommand::FileCommand::RemoveArgs.new(@file))
+        cc = Rundoc::CodeCommand::FileCommand::RemoveRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::FileCommand::RemoveArgs.new(@file))
         cc << "gem 'sqlite3'"
         cc.call
 

--- a/test/rundoc/code_section_test.rb
+++ b/test/rundoc/code_section_test.rb
@@ -19,7 +19,8 @@ class CodeSectionTest < Minitest::Test
           fence: match[:fence],
           lang: match[:lang],
           code: match[:contents],
-          context: default_context
+          context: default_context,
+          io: StringIO.new
         ).render
         assert_equal "", result
       end
@@ -39,7 +40,8 @@ class CodeSectionTest < Minitest::Test
       fence: match[:fence],
       lang: match[:lang],
       code: match[:contents],
-      context: default_context
+      context: default_context,
+      io: StringIO.new
     ).render
     assert_equal contents, result.gsub(Rundoc::FencedCodeBlock::AUTOGEN_WARNING, "\n")
   end
@@ -56,7 +58,8 @@ class CodeSectionTest < Minitest::Test
       fence: match[:fence],
       lang: match[:lang],
       code: match[:contents],
-      context: default_context
+      context: default_context,
+      io: StringIO.new
     )
     code_section.render
 
@@ -75,7 +78,8 @@ class CodeSectionTest < Minitest::Test
       fence: match[:fence],
       lang: match[:lang],
       code: match[:contents],
-      context: default_context
+      context: default_context,
+      io: StringIO.new
     )
     code_section.render
 
@@ -96,11 +100,11 @@ class CodeSectionTest < Minitest::Test
       fence: match[:fence],
       lang: match[:lang],
       code: match[:contents],
-      context: default_context
+      context: default_context,
+      io: StringIO.new
     )
     code_section.render
 
-    puts code_section.executed_commands.inspect
     code_command = code_section.executed_commands.first
     assert_equal true, code_command.render_command?
     assert_equal true, code_command.render_result?
@@ -118,7 +122,8 @@ class CodeSectionTest < Minitest::Test
       fence: match[:fence],
       lang: match[:lang],
       code: match[:contents],
-      context: default_context
+      context: default_context,
+      io: StringIO.new
     )
     code_section.render
 
@@ -137,7 +142,8 @@ class CodeSectionTest < Minitest::Test
       fence: match[:fence],
       lang: match[:lang],
       code: match[:contents],
-      context: default_context
+      context: default_context,
+      io: StringIO.new
     )
     code_section.render
 
@@ -158,7 +164,8 @@ class CodeSectionTest < Minitest::Test
       fence: match[:fence],
       lang: match[:lang],
       code: match[:contents],
-      context: default_context
+      context: default_context,
+      io: StringIO.new
     )
     code_section.render
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,7 +33,8 @@ class Minitest::Test
     contents,
     output_dir: nil,
     source_path: nil,
-    screenshots_dirname: nil
+    screenshots_dirname: nil,
+    io: StringIO.new
   )
     context = default_context(
       output_dir: output_dir,
@@ -42,7 +43,8 @@ class Minitest::Test
     )
     Rundoc::Document.new(
       contents,
-      context: context
+      context: context,
+      io: io
     )
   end
 


### PR DESCRIPTION
Bare `puts` to `$stdout` made runner output impossible to capture, redirect, or silence in tests. Injecting `io:` makes output controllable — the CLI wires it to `$stderr`, tests pass `StringIO.new`, and programmatic callers can send it wherever they want.

Stack: 3/4 — #110 → #111 → this → #113