### PR TITLE
Add frozen_string_literal pragma to all lib files

### DIFF
--- a/lib/rundoc/cli.rb
+++ b/lib/rundoc/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   class CLI
     module DEFAULTS

--- a/lib/rundoc/code_command.rb
+++ b/lib/rundoc/code_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   # Generic CodeCommand class to be inherited
   #
@@ -30,7 +32,7 @@ module Rundoc
     end
 
     def push(contents)
-      @contents ||= ""
+      @contents ||= +""
       @contents << contents
     end
     alias_method :<<, :push

--- a/lib/rundoc/code_command/background.rb
+++ b/lib/rundoc/code_command/background.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::Background
 end
 

--- a/lib/rundoc/code_command/background/log/clear.rb
+++ b/lib/rundoc/code_command/background/log/clear.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::Background::Log
   class ClearArgs
     attr_reader :name

--- a/lib/rundoc/code_command/background/log/read.rb
+++ b/lib/rundoc/code_command/background/log/read.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::Background::Log
   class ReadArgs
     attr_reader :name

--- a/lib/rundoc/code_command/background/process_spawn.rb
+++ b/lib/rundoc/code_command/background/process_spawn.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "shellwords"
 require "timeout"
 require "fileutils"

--- a/lib/rundoc/code_command/background/start.rb
+++ b/lib/rundoc/code_command/background/start.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "tempfile"
 
 class Rundoc::CodeCommand::Background

--- a/lib/rundoc/code_command/background/stdin_write.rb
+++ b/lib/rundoc/code_command/background/stdin_write.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::Background
   class StdinWriteArgs
     attr_reader :contents, :name, :wait, :timeout, :ending

--- a/lib/rundoc/code_command/background/stop.rb
+++ b/lib/rundoc/code_command/background/stop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::Background
   class StopArgs
     attr_reader :name

--- a/lib/rundoc/code_command/background/wait.rb
+++ b/lib/rundoc/code_command/background/wait.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::Background
   class WaitArgs
     attr_reader :name, :wait, :timeout

--- a/lib/rundoc/code_command/bash.rb
+++ b/lib/rundoc/code_command/bash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::BashArgs
   attr_reader :line
 
@@ -42,11 +44,11 @@ class Rundoc::CodeCommand::BashRunner < Rundoc::CodeCommand
 
   def shell(cmd, stdin = nil)
     cmd = "(#{cmd}) 2>&1"
-    msg = "Running: $ '#{cmd}'"
+    msg = +"Running: $ '#{cmd}'"
     msg << " with stdin: '#{stdin.inspect}'" if stdin && !stdin.empty?
     io.puts msg
 
-    result = ""
+    result = +""
     IO.popen(cmd, "w+") do |pipe|
       pipe << stdin if stdin
       pipe.close_write

--- a/lib/rundoc/code_command/bash.rb
+++ b/lib/rundoc/code_command/bash.rb
@@ -44,7 +44,7 @@ class Rundoc::CodeCommand::BashRunner < Rundoc::CodeCommand
 
   def shell(cmd, stdin = nil)
     cmd = "(#{cmd}) 2>&1"
-    msg = +"Running: $ '#{cmd}'"
+    msg = "Running: $ '#{cmd}'"
     msg << " with stdin: '#{stdin.inspect}'" if stdin && !stdin.empty?
     io.puts msg
 

--- a/lib/rundoc/code_command/bash/cd.rb
+++ b/lib/rundoc/code_command/bash/cd.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::BashRunner
   class Cd < Rundoc::CodeCommand::BashRunner
     def initialize(line, io: $stdout)

--- a/lib/rundoc/code_command/deferred.rb
+++ b/lib/rundoc/code_command/deferred.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   class CodeCommand
     # Hold enough information to construct commands, but don't yet
@@ -31,7 +33,7 @@ module Rundoc
       end
 
       def push(contents)
-        @contents ||= ""
+        @contents ||= +""
         @contents << contents
       end
       alias_method :<<, :push

--- a/lib/rundoc/code_command/file_command/append.rb
+++ b/lib/rundoc/code_command/file_command/append.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::FileCommand
   class AppendArgs
     attr_reader :filename
@@ -43,7 +45,7 @@ class Rundoc::CodeCommand::FileCommand
     end
 
     def concat_with_newline(str1, str2)
-      result = ""
+      result = +""
       result << str1
       result << "\n" unless ends_in_newline?(result)
       result << str2

--- a/lib/rundoc/code_command/file_command/remove.rb
+++ b/lib/rundoc/code_command/file_command/remove.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::FileCommand
   class RemoveArgs
     attr_reader :filename

--- a/lib/rundoc/code_command/no_such_command.rb
+++ b/lib/rundoc/code_command/no_such_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   class CodeCommand
     class NoSuchCommand < Rundoc::CodeCommand

--- a/lib/rundoc/code_command/pipe.rb
+++ b/lib/rundoc/code_command/pipe.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   class CodeCommand
     class PipeArgs

--- a/lib/rundoc/code_command/pre/erb.rb
+++ b/lib/rundoc/code_command/pre/erb.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../print/erb"
 
 class Rundoc::CodeCommand

--- a/lib/rundoc/code_command/print/erb.rb
+++ b/lib/rundoc/code_command/print/erb.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "erb"
 
 class EmptyBinding

--- a/lib/rundoc/code_command/print/text.rb
+++ b/lib/rundoc/code_command/print/text.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand
   class PrintTextArgs
     attr_reader :line

--- a/lib/rundoc/code_command/raw.rb
+++ b/lib/rundoc/code_command/raw.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   class CodeCommand
     class Raw < CodeCommand

--- a/lib/rundoc/code_command/rundoc/require.rb
+++ b/lib/rundoc/code_command/rundoc/require.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ::Rundoc::CodeCommand
   class RundocCommand
     class RequireArgs

--- a/lib/rundoc/code_command/rundoc_command.rb
+++ b/lib/rundoc/code_command/rundoc_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ::Rundoc
   class CodeCommand
     class RundocCommandArgs

--- a/lib/rundoc/code_command/website.rb
+++ b/lib/rundoc/code_command/website.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::Website
 end
 

--- a/lib/rundoc/code_command/website/driver.rb
+++ b/lib/rundoc/code_command/website/driver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "capybara"
 
 Capybara::Selenium::Driver.load_selenium

--- a/lib/rundoc/code_command/website/navigate.rb
+++ b/lib/rundoc/code_command/website/navigate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::Website
   class NavigateArgs
     attr_reader :name

--- a/lib/rundoc/code_command/website/screenshot.rb
+++ b/lib/rundoc/code_command/website/screenshot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rundoc::CodeCommand::Website
   class ScreenshotArgs
     attr_reader :name, :upload

--- a/lib/rundoc/code_command/website/visit.rb
+++ b/lib/rundoc/code_command/website/visit.rb
@@ -45,7 +45,7 @@ class Rundoc::CodeCommand::Website
     end
 
     def call(env = {})
-      message = +"Visting: #{@url}"
+      message = "Visting: #{@url}"
       message << "and executing:\n#{contents}" unless contents.nil? || contents.empty?
 
       io.puts message

--- a/lib/rundoc/code_command/website/visit.rb
+++ b/lib/rundoc/code_command/website/visit.rb
@@ -45,7 +45,7 @@ class Rundoc::CodeCommand::Website
     end
 
     def call(env = {})
-      message = "Visting: #{@url}"
+      message = +"Visting: #{@url}"
       message << "and executing:\n#{contents}" unless contents.nil? || contents.empty?
 
       io.puts message

--- a/lib/rundoc/code_command/write.rb
+++ b/lib/rundoc/code_command/write.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   class CodeCommand
     module FileUtil

--- a/lib/rundoc/context/after_build.rb
+++ b/lib/rundoc/context/after_build.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   module Context
     # Public interface for the `Rundoc.after_build` proc

--- a/lib/rundoc/context/execution.rb
+++ b/lib/rundoc/context/execution.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   module Context
     # Holds configuration for the currently executing script

--- a/lib/rundoc/document.rb
+++ b/lib/rundoc/document.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   # Represents a single rundoc file on disk,
   #

--- a/lib/rundoc/peg_parser.rb
+++ b/lib/rundoc/peg_parser.rb
@@ -244,8 +244,8 @@ module Rundoc
         raise TransformError.new(message: message, line_and_column: line_and_column)
       end
       Visability.new(
-        command: command.to_s == ">".freeze,
-        result: result.to_s == ">".freeze
+        command: command.to_s == ">",
+        result: result.to_s == ">"
       )
     }
 

--- a/lib/rundoc/peg_parser.rb
+++ b/lib/rundoc/peg_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "parslet"
 
 module Rundoc

--- a/lib/rundoc/version.rb
+++ b/lib/rundoc/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rundoc
   VERSION = "4.1.4"
 end


### PR DESCRIPTION
Ruby will freeze all string literals by default in a future version. Adding the pragma now catches any code that mutates string literals before that becomes a hard error.

Stack: 4/4 — #110 → #111 → #113 → this