### PR TITLE
Drop Ruby 3.1 support, require Ruby 3.2+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 3.1
           - 3.2
           - 3.3
+          - "4.0"
           - head
     steps:
       - name: Checkout code
@@ -34,6 +34,7 @@ jobs:
       matrix:
         ruby:
           - 3.3
+          - "4.0"
           - head
     steps:
       - name: Checkout code

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,6 +1,6 @@
 fix: true               # default: false
 parallel: true          # default: false
 format: progress        # default: Standard::Formatter
-ruby_version: 3.1       # default: RUBY_VERSION
+ruby_version: 3.2       # default: RUBY_VERSION
 ignore:                 # default: []
   - 'test/fixtures/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+- Changed: Minimum Ruby version is now 3.2 (Ruby 3.1 reached EOL in March 2025).
 - Changed: All code commands now use an Args + Runner class pattern. `register_code_command` now requires keyword arguments: `keyword:`, `args_klass:`, and `runner_klass:`.
 
 ## 4.1.4

--- a/rundoc.gemspec
+++ b/rundoc.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |gem|
   gem.executables = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.require_paths = ["lib"]
 
+  gem.required_ruby_version = ">= 3.2"
+
   gem.add_dependency "thor"
   gem.add_dependency "parslet", "~> 2"
   gem.add_dependency "capybara", "~> 3"


### PR DESCRIPTION
Ruby 3.1 reached [EOL in March 2025](https://www.ruby-lang.org/en/downloads/branches/). Upcoming refactoring uses `super(**)` syntax which requires Ruby 3.2+.

Also adds Ruby 4.0 to the CI test and lint matrices.