### PR TITLE
Internal refactor Reduce API surface area for CodeCommand

### DIFF
--- a/lib/rundoc/code_command.rb
+++ b/lib/rundoc/code_command.rb
@@ -12,7 +12,7 @@ module Rundoc
       @io = io
       @render_command = render_command
       @render_result = render_result
-      push(contents) if contents && !contents.empty?
+      @contents = contents.dup if contents && !contents.empty?
     end
 
     def render_result?

--- a/lib/rundoc/code_command.rb
+++ b/lib/rundoc/code_command.rb
@@ -31,12 +31,6 @@ module Rundoc
       !hidden?
     end
 
-    def push(contents)
-      @contents ||= +""
-      @contents << contents
-    end
-    alias_method :<<, :push
-
     # Executes command to build project
     # Is expected to return the result of the command
     def call(env = {})

--- a/lib/rundoc/code_command/pipe.rb
+++ b/lib/rundoc/code_command/pipe.rb
@@ -25,7 +25,7 @@ module Rundoc
         io.puts "Piping: results of '#{last_command[:command]}' to '#{@delegate}'"
 
         @delegate.push(last_command[:output])
-        @delegate.call(env)
+        @delegate.build(io: io).call(env)
       end
 
       def to_md(env = {})
@@ -39,17 +39,23 @@ module Rundoc
 
         actual = actual.first if actual.is_a?(Array)
 
-        # Unregistered keywords (e.g. `| tail -n 2`) aren't rundoc commands — treat them as bash
         if actual.runner_klass == Rundoc::CodeCommand::NoSuchCommand
-          Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new(code), render_command: false, render_result: false, io: io)
+          bash_deferred(code)
         else
-          actual.build(io: io)
+          actual
         end
-
-      # Since `| tail -n 2` does not start with a `$` assume any "naked" commands
-      # are bash
       rescue Parslet::ParseFailed
-        Rundoc::CodeCommand::BashRunner.new(user_args: Rundoc::CodeCommand::BashArgs.new(code), render_command: false, render_result: false, io: io)
+        bash_deferred(code)
+      end
+
+      private def bash_deferred(code)
+        deferred = Rundoc::CodeCommand::Deferred.new(
+          args_instance: Rundoc::CodeCommand::BashArgs.new(code),
+          runner_klass: Rundoc::CodeCommand::BashRunner
+        )
+        deferred.render_command = false
+        deferred.render_result = false
+        deferred
       end
     end
   end

--- a/lib/rundoc/code_command/rundoc_command.rb
+++ b/lib/rundoc/code_command/rundoc_command.rb
@@ -3,17 +3,17 @@
 module ::Rundoc
   class CodeCommand
     class RundocCommandArgs
-      attr_reader :contents
+      attr_reader :code
 
-      def initialize(contents = "")
-        @contents = contents
+      def initialize(code = "")
+        @code = code
       end
     end
 
     class RundocCommandRunner < ::Rundoc::CodeCommand
       def initialize(user_args:, **)
-        @contents = user_args.contents
         super(**)
+        @contents = user_args.code + @contents
       end
 
       def to_md(env = {})

--- a/test/rundoc/code_commands/append_file_test.rb
+++ b/test/rundoc/code_commands/append_file_test.rb
@@ -7,8 +7,13 @@ class AppendFileTest < Minitest::Test
         file = "foo.rb"
         `echo 'foo' >> #{file}`
 
-        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file))
-        cc << "bar"
+        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(
+          render_command: false,
+          render_result: false,
+          io: StringIO.new,
+          user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file),
+          contents: "bar"
+        )
         cc.call
 
         result = File.read(file)
@@ -16,8 +21,13 @@ class AppendFileTest < Minitest::Test
         assert_match(/foo/, result)
         assert_match(/bar/, result)
 
-        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file))
-        cc << "baz"
+        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(
+          render_command: false,
+          render_result: false,
+          io: StringIO.new,
+          user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file),
+          contents: "baz"
+        )
         cc.call
 
         actual = File.read(file)
@@ -39,8 +49,13 @@ class AppendFileTest < Minitest::Test
         line = 2
         `echo '#{contents}' >> #{file}`
 
-        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("#{file}##{line}"))
-        cc << "gem 'pg'"
+        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(
+          render_command: false,
+          render_result: false,
+          io: StringIO.new,
+          user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("#{file}##{line}"),
+          contents: "gem 'pg'"
+        )
         cc.call
 
         expected = "source https://rubygems.org\ngem 'pg'\ngem rails, 4.0.0\n\n"
@@ -54,8 +69,13 @@ class AppendFileTest < Minitest::Test
       Dir.chdir(dir) do
         filename = "file-#{Time.now.utc.strftime("%Y%m%d%H%M%S")}.txt"
         FileUtils.touch(filename)
-        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("file-*.txt"))
-        cc << "some text"
+        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(
+          render_command: false,
+          render_result: false,
+          io: StringIO.new,
+          user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("file-*.txt"),
+          contents: "some text"
+        )
         cc.call
 
         assert_equal "\nsome text\n", File.read(filename)
@@ -69,8 +89,13 @@ class AppendFileTest < Minitest::Test
         FileUtils.touch("file-1234.txt")
         FileUtils.touch("file-5678.txt")
         assert_raises do
-          cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("file-*.txt"))
-          cc << "some text"
+          cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(
+            render_command: false,
+            render_result: false,
+            io: StringIO.new,
+            user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("file-*.txt"),
+            contents: "some text"
+          )
           cc.call
         end
       end

--- a/test/rundoc/code_commands/bash_test.rb
+++ b/test/rundoc/code_commands/bash_test.rb
@@ -27,8 +27,13 @@ class BashTest < Minitest::Test
 
   def test_stdin
     command = "tail -n 2"
-    bash = Rundoc::CodeCommand::BashRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::BashArgs.new(command))
-    bash << "foo\nbar\nbaz\n"
+    bash = Rundoc::CodeCommand::BashRunner.new(
+      render_command: false,
+      render_result: false,
+      io: StringIO.new,
+      user_args: Rundoc::CodeCommand::BashArgs.new(command),
+      contents: "foo\nbar\nbaz\n"
+    )
     assert_equal "bar\nbaz\n", bash.call
   end
 end

--- a/test/rundoc/code_commands/remove_contents_test.rb
+++ b/test/rundoc/code_commands/remove_contents_test.rb
@@ -21,8 +21,13 @@ class RemoveContentsTest < Minitest::Test
 
         assert_match(/sqlite3/, File.read(@file))
 
-        cc = Rundoc::CodeCommand::FileCommand::RemoveRunner.new(render_command: false, render_result: false, io: StringIO.new, user_args: Rundoc::CodeCommand::FileCommand::RemoveArgs.new(@file))
-        cc << "gem 'sqlite3'"
+        cc = Rundoc::CodeCommand::FileCommand::RemoveRunner.new(
+          render_command: false,
+          render_result: false,
+          user_args: Rundoc::CodeCommand::FileCommand::RemoveArgs.new(@file),
+          contents: "gem 'sqlite3'",
+          io: StringIO.new
+        )
         cc.call
 
         refute_match(/sqlite3/, File.read(@file))


### PR DESCRIPTION
Runner instances inherit from CodeCommand which has a mutable `push()` method `<<`. This is to set the contents of a command; this "contents" command is used like this:

    ```
    :::>- file.write config/routes.rb

    Example::Application.routes.draw do
      root        :to => "pages#index"

      namespace :users do
        resources :after_signup
      end
    end
    ```

Where the contents are the elements below the command. By moving where these are accumulated, the runner code can be simplified, and runners become more functionally pure and easier to reason about and work with.