### PR TITLE
Refactor Runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,11 +688,11 @@ class Rundoc::CodeCommand::LolArgs
 end
 ```
 
-The Runner class inherits from `Rundoc::CodeCommand` and receives the args instance via `user_args:`:
+The Runner class is namespaced under `Rundoc::CodeCommand` and receives the args instance via `user_args:`:
 
 ```ruby
-class Rundoc::CodeCommand::LolRunner < Rundoc::CodeCommand
-  def initialize(user_args:)
+class Rundoc::CodeCommand::LolRunner
+  def initialize(user_args:, **)
     @message = user_args.message
   end
 

--- a/lib/rundoc.rb
+++ b/lib/rundoc.rb
@@ -29,7 +29,8 @@ module Rundoc
 
     deferred = CodeCommand::Deferred.new(
       args_instance: user_args,
-      runner_klass: runner_klass
+      runner_klass: runner_klass,
+      always_hidden: always_hidden_commands[keyword]
     )
     deferred.original_args = original_args
     deferred.keyword = keyword
@@ -62,9 +63,14 @@ module Rundoc
     user_args.keys
   end
 
-  def register_code_command(keyword:, args_klass:, runner_klass:)
+  def register_code_command(keyword:, args_klass:, runner_klass:, always_hidden: false)
     user_args[keyword] = args_klass
     user_args_runner[keyword] = runner_klass
+    always_hidden_commands[keyword] = always_hidden
+  end
+
+  def always_hidden_commands
+    @always_hidden_commands ||= {}
   end
 
   def configure(&block)

--- a/lib/rundoc/code_command.rb
+++ b/lib/rundoc/code_command.rb
@@ -4,9 +4,7 @@ module Rundoc
   # Generic CodeCommand class to be inherited
   #
   class CodeCommand
-    attr_accessor :contents
-
-    attr_reader :io
+    attr_reader :io, :contents
 
     def initialize(render_command:, render_result:, io:, contents: nil)
       @io = io

--- a/lib/rundoc/code_command.rb
+++ b/lib/rundoc/code_command.rb
@@ -1,36 +1,7 @@
 # frozen_string_literal: true
 
 module Rundoc
-  # Generic CodeCommand class to be inherited
-  #
-  class CodeCommand
-    attr_reader :io, :contents
-
-    def initialize(render_command:, render_result:, io:, contents: nil)
-      @io = io
-      @render_command = render_command
-      @render_result = render_result
-      @contents = contents.dup if contents && !contents.empty?
-    end
-
-    def render_result?
-      @render_result
-    end
-
-    def render_command?
-      @render_command
-    end
-
-    # Executes command to build project
-    # Is expected to return the result of the command
-    def call(env = {})
-      raise "not implemented on #{inspect}"
-    end
-
-    # the output of the command, i.e. `$ cat foo.txt`
-    def to_md(env = {})
-      raise "not implemented on #{inspect}"
-    end
+  module CodeCommand
   end
 end
 

--- a/lib/rundoc/code_command.rb
+++ b/lib/rundoc/code_command.rb
@@ -21,14 +21,6 @@ module Rundoc
       @render_command
     end
 
-    def hidden?
-      !render_command? && !render_result?
-    end
-
-    def not_hidden?
-      !hidden?
-    end
-
     # Executes command to build project
     # Is expected to return the result of the command
     def call(env = {})

--- a/lib/rundoc/code_command/background/log/clear.rb
+++ b/lib/rundoc/code_command/background/log/clear.rb
@@ -9,15 +9,24 @@ class Rundoc::CodeCommand::Background::Log
     end
   end
 
-  class ClearRunner < Rundoc::CodeCommand
-    def initialize(user_args:, **)
+  class ClearRunner
+    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil, **)
       @name = user_args.name
       @background = nil
-      super(**)
+      @render_command = render_command
+      @render_result = render_result
     end
 
     def background
       @background ||= Rundoc::CodeCommand::Background::ProcessSpawn.find(@name)
+    end
+
+    def render_command?
+      @render_command
+    end
+
+    def render_result?
+      @render_result
     end
 
     def to_md(env = {})

--- a/lib/rundoc/code_command/background/log/clear.rb
+++ b/lib/rundoc/code_command/background/log/clear.rb
@@ -13,20 +13,10 @@ class Rundoc::CodeCommand::Background::Log
     def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil)
       @name = user_args.name
       @background = nil
-      @render_command = render_command
-      @render_result = render_result
     end
 
     def background
       @background ||= Rundoc::CodeCommand::Background::ProcessSpawn.find(@name)
-    end
-
-    def render_command?
-      @render_command
-    end
-
-    def render_result?
-      @render_result
     end
 
     def to_md(env = {})

--- a/lib/rundoc/code_command/background/log/clear.rb
+++ b/lib/rundoc/code_command/background/log/clear.rb
@@ -10,7 +10,7 @@ class Rundoc::CodeCommand::Background::Log
   end
 
   class ClearRunner
-    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil, **)
+    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil)
       @name = user_args.name
       @background = nil
       @render_command = render_command

--- a/lib/rundoc/code_command/background/log/read.rb
+++ b/lib/rundoc/code_command/background/log/read.rb
@@ -9,15 +9,24 @@ class Rundoc::CodeCommand::Background::Log
     end
   end
 
-  class ReadRunner < Rundoc::CodeCommand
-    def initialize(user_args:, **)
+  class ReadRunner
+    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil, **)
       @name = user_args.name
       @background = nil
-      super(**)
+      @render_command = render_command
+      @render_result = render_result
     end
 
     def background
       @background ||= Rundoc::CodeCommand::Background::ProcessSpawn.find(@name)
+    end
+
+    def render_command?
+      @render_command
+    end
+
+    def render_result?
+      @render_result
     end
 
     def to_md(env = {})

--- a/lib/rundoc/code_command/background/log/read.rb
+++ b/lib/rundoc/code_command/background/log/read.rb
@@ -13,20 +13,10 @@ class Rundoc::CodeCommand::Background::Log
     def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil)
       @name = user_args.name
       @background = nil
-      @render_command = render_command
-      @render_result = render_result
     end
 
     def background
       @background ||= Rundoc::CodeCommand::Background::ProcessSpawn.find(@name)
-    end
-
-    def render_command?
-      @render_command
-    end
-
-    def render_result?
-      @render_result
     end
 
     def to_md(env = {})

--- a/lib/rundoc/code_command/background/log/read.rb
+++ b/lib/rundoc/code_command/background/log/read.rb
@@ -10,7 +10,7 @@ class Rundoc::CodeCommand::Background::Log
   end
 
   class ReadRunner
-    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil, **)
+    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil)
       @name = user_args.name
       @background = nil
       @render_command = render_command

--- a/lib/rundoc/code_command/background/start.rb
+++ b/lib/rundoc/code_command/background/start.rb
@@ -17,8 +17,10 @@ class Rundoc::CodeCommand::Background
     end
   end
 
-  class StartRunner < Rundoc::CodeCommand
-    def initialize(user_args:, **)
+  class StartRunner
+    attr_reader :io
+
+    def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
       @timeout = user_args.timeout
       @command = user_args.command
       @name = user_args.name
@@ -29,7 +31,9 @@ class Rundoc::CodeCommand::Background
       FileUtils.touch(@log)
 
       @background = nil
-      super(**)
+      @io = io
+      @render_command = render_command
+      @render_result = render_result
     end
 
     def background
@@ -42,6 +46,14 @@ class Rundoc::CodeCommand::Background
         io.puts "Spawning commmand: `#{spawn.command}`"
         ProcessSpawn.add(@name, spawn)
       end
+    end
+
+    def render_command?
+      @render_command
+    end
+
+    def render_result?
+      @render_result
     end
 
     def to_md(env = {})

--- a/lib/rundoc/code_command/background/start.rb
+++ b/lib/rundoc/code_command/background/start.rb
@@ -32,8 +32,6 @@ class Rundoc::CodeCommand::Background
 
       @background = nil
       @io = io
-      @render_command = render_command
-      @render_result = render_result
     end
 
     def background
@@ -46,14 +44,6 @@ class Rundoc::CodeCommand::Background
         io.puts "Spawning commmand: `#{spawn.command}`"
         ProcessSpawn.add(@name, spawn)
       end
-    end
-
-    def render_command?
-      @render_command
-    end
-
-    def render_result?
-      @render_result
     end
 
     def to_md(env = {})

--- a/lib/rundoc/code_command/background/start.rb
+++ b/lib/rundoc/code_command/background/start.rb
@@ -20,7 +20,7 @@ class Rundoc::CodeCommand::Background
   class StartRunner
     attr_reader :io
 
-    def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
+    def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
       @timeout = user_args.timeout
       @command = user_args.command
       @name = user_args.name

--- a/lib/rundoc/code_command/background/stdin_write.rb
+++ b/lib/rundoc/code_command/background/stdin_write.rb
@@ -24,20 +24,10 @@ class Rundoc::CodeCommand::Background
       @timeout_value = user_args.timeout
       @contents_written = nil
       @background = nil
-      @render_command = render_command
-      @render_result = render_result
     end
 
     def background
       @background ||= Rundoc::CodeCommand::Background::ProcessSpawn.find(@name)
-    end
-
-    def render_command?
-      @render_command
-    end
-
-    def render_result?
-      @render_result
     end
 
     # The command is rendered (`:::>-`) by the output of the `def call` method.

--- a/lib/rundoc/code_command/background/stdin_write.rb
+++ b/lib/rundoc/code_command/background/stdin_write.rb
@@ -16,7 +16,7 @@ class Rundoc::CodeCommand::Background
   class StdinWriteRunner
     attr_reader :contents
 
-    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil, **)
+    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil)
       @contents = user_args.contents
       @ending = user_args.ending
       @wait = user_args.wait

--- a/lib/rundoc/code_command/background/stdin_write.rb
+++ b/lib/rundoc/code_command/background/stdin_write.rb
@@ -13,8 +13,10 @@ class Rundoc::CodeCommand::Background
     end
   end
 
-  class StdinWriteRunner < Rundoc::CodeCommand
-    def initialize(user_args:, **)
+  class StdinWriteRunner
+    attr_reader :contents
+
+    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil, **)
       @contents = user_args.contents
       @ending = user_args.ending
       @wait = user_args.wait
@@ -22,11 +24,20 @@ class Rundoc::CodeCommand::Background
       @timeout_value = user_args.timeout
       @contents_written = nil
       @background = nil
-      super(**)
+      @render_command = render_command
+      @render_result = render_result
     end
 
     def background
       @background ||= Rundoc::CodeCommand::Background::ProcessSpawn.find(@name)
+    end
+
+    def render_command?
+      @render_command
+    end
+
+    def render_result?
+      @render_result
     end
 
     # The command is rendered (`:::>-`) by the output of the `def call` method.

--- a/lib/rundoc/code_command/background/stop.rb
+++ b/lib/rundoc/code_command/background/stop.rb
@@ -10,7 +10,7 @@ class Rundoc::CodeCommand::Background
   end
 
   class StopRunner
-    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil, **)
+    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil)
       @name = user_args.name
       @background = nil
       @render_command = render_command

--- a/lib/rundoc/code_command/background/stop.rb
+++ b/lib/rundoc/code_command/background/stop.rb
@@ -9,15 +9,24 @@ class Rundoc::CodeCommand::Background
     end
   end
 
-  class StopRunner < Rundoc::CodeCommand
-    def initialize(user_args:, **)
+  class StopRunner
+    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil, **)
       @name = user_args.name
       @background = nil
-      super(**)
+      @render_command = render_command
+      @render_result = render_result
     end
 
     def background
       @background ||= Rundoc::CodeCommand::Background::ProcessSpawn.find(@name)
+    end
+
+    def render_command?
+      @render_command
+    end
+
+    def render_result?
+      @render_result
     end
 
     def to_md(env = {})

--- a/lib/rundoc/code_command/background/stop.rb
+++ b/lib/rundoc/code_command/background/stop.rb
@@ -13,20 +13,10 @@ class Rundoc::CodeCommand::Background
     def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil)
       @name = user_args.name
       @background = nil
-      @render_command = render_command
-      @render_result = render_result
     end
 
     def background
       @background ||= Rundoc::CodeCommand::Background::ProcessSpawn.find(@name)
-    end
-
-    def render_command?
-      @render_command
-    end
-
-    def render_result?
-      @render_result
     end
 
     def to_md(env = {})

--- a/lib/rundoc/code_command/background/wait.rb
+++ b/lib/rundoc/code_command/background/wait.rb
@@ -17,20 +17,10 @@ class Rundoc::CodeCommand::Background
       @wait = user_args.wait
       @timeout_value = user_args.timeout
       @background = nil
-      @render_command = render_command
-      @render_result = render_result
     end
 
     def background
       @background ||= Rundoc::CodeCommand::Background::ProcessSpawn.find(@name)
-    end
-
-    def render_command?
-      @render_command
-    end
-
-    def render_result?
-      @render_result
     end
 
     def to_md(env = {})

--- a/lib/rundoc/code_command/background/wait.rb
+++ b/lib/rundoc/code_command/background/wait.rb
@@ -11,17 +11,26 @@ class Rundoc::CodeCommand::Background
     end
   end
 
-  class WaitRunner < Rundoc::CodeCommand
-    def initialize(user_args:, **)
+  class WaitRunner
+    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil, **)
       @name = user_args.name
       @wait = user_args.wait
       @timeout_value = user_args.timeout
       @background = nil
-      super(**)
+      @render_command = render_command
+      @render_result = render_result
     end
 
     def background
       @background ||= Rundoc::CodeCommand::Background::ProcessSpawn.find(@name)
+    end
+
+    def render_command?
+      @render_command
+    end
+
+    def render_result?
+      @render_result
     end
 
     def to_md(env = {})

--- a/lib/rundoc/code_command/background/wait.rb
+++ b/lib/rundoc/code_command/background/wait.rb
@@ -12,7 +12,7 @@ class Rundoc::CodeCommand::Background
   end
 
   class WaitRunner
-    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil, **)
+    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil)
       @name = user_args.name
       @wait = user_args.wait
       @timeout_value = user_args.timeout

--- a/lib/rundoc/code_command/bash.rb
+++ b/lib/rundoc/code_command/bash.rb
@@ -13,8 +13,6 @@ class Rundoc::CodeCommand::BashRunner
 
   def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
     @io = io
-    @render_command = render_command
-    @render_result = render_result
     @contents = contents.dup if contents && !contents.empty?
     @line = user_args.line
     @delegate = case @line.split(" ").first.downcase
@@ -23,14 +21,6 @@ class Rundoc::CodeCommand::BashRunner
     else
       false
     end
-  end
-
-  def render_command?
-    @render_command
-  end
-
-  def render_result?
-    @render_result
   end
 
   def raise_on_error?

--- a/lib/rundoc/code_command/bash.rb
+++ b/lib/rundoc/code_command/bash.rb
@@ -11,7 +11,7 @@ end
 class Rundoc::CodeCommand::BashRunner
   attr_reader :io, :contents
 
-  def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
+  def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
     @io = io
     @render_command = render_command
     @render_result = render_result

--- a/lib/rundoc/code_command/bash.rb
+++ b/lib/rundoc/code_command/bash.rb
@@ -8,9 +8,14 @@ class Rundoc::CodeCommand::BashArgs
   end
 end
 
-class Rundoc::CodeCommand::BashRunner < Rundoc::CodeCommand
-  def initialize(user_args:, **)
-    super(**)
+class Rundoc::CodeCommand::BashRunner
+  attr_reader :io, :contents
+
+  def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
+    @io = io
+    @render_command = render_command
+    @render_result = render_result
+    @contents = contents.dup if contents && !contents.empty?
     @line = user_args.line
     @delegate = case @line.split(" ").first.downcase
     when "cd"
@@ -20,7 +25,14 @@ class Rundoc::CodeCommand::BashRunner < Rundoc::CodeCommand
     end
   end
 
-  # predicate to over-write for failure support
+  def render_command?
+    @render_command
+  end
+
+  def render_result?
+    @render_result
+  end
+
   def raise_on_error?
     true
   end

--- a/lib/rundoc/code_command/deferred.rb
+++ b/lib/rundoc/code_command/deferred.rb
@@ -21,11 +21,7 @@ module Rundoc
       end
 
       def hidden?
-        if @built
-          @built.hidden?
-        else
-          !render_command? && !render_result?
-        end
+        !render_command? && !render_result?
       end
 
       def not_hidden?
@@ -39,13 +35,18 @@ module Rundoc
       alias_method :<<, :push
 
       def build(io: $stdout)
-        @built ||= @runner_klass.new(
-          user_args: @args_instance,
-          render_command: render_command,
-          render_result: render_result,
-          contents: @contents,
-          io: io
-        )
+        @built ||= begin
+          runner = @runner_klass.new(
+            user_args: @args_instance,
+            render_command: render_command,
+            render_result: render_result,
+            contents: @contents,
+            io: io
+          )
+          @render_command = runner.render_command?
+          @render_result = runner.render_result?
+          runner
+        end
       rescue UnknownCommand
         raise "No such command registered with rundoc #{keyword.inspect} for `#{keyword} #{original_args}`"
       end

--- a/lib/rundoc/code_command/deferred.rb
+++ b/lib/rundoc/code_command/deferred.rb
@@ -15,9 +15,10 @@ module Rundoc
 
       attr_reader :runner_klass
 
-      def initialize(args_instance:, runner_klass:)
+      def initialize(args_instance:, runner_klass:, always_hidden: false)
         @args_instance = args_instance
         @runner_klass = runner_klass
+        @always_hidden = always_hidden
       end
 
       def hidden?
@@ -43,8 +44,10 @@ module Rundoc
             contents: @contents,
             io: io
           )
-          @render_command = runner.render_command?
-          @render_result = runner.render_result?
+          if @always_hidden
+            @render_command = false
+            @render_result = false
+          end
           runner
         end
       rescue UnknownCommand

--- a/lib/rundoc/code_command/deferred.rb
+++ b/lib/rundoc/code_command/deferred.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Rundoc
-  class CodeCommand
+  module CodeCommand
     # Hold enough information to construct commands, but don't yet
     #
     # Allows us to separate parse time constructs from runtime injectables

--- a/lib/rundoc/code_command/file_command/append.rb
+++ b/lib/rundoc/code_command/file_command/append.rb
@@ -16,7 +16,7 @@ class Rundoc::CodeCommand::FileCommand
 
     attr_reader :io, :contents
 
-    def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
+    def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
       @filename, line = user_args.filename.split("#")
       @line_number = if line
         Integer(line)

--- a/lib/rundoc/code_command/file_command/append.rb
+++ b/lib/rundoc/code_command/file_command/append.rb
@@ -23,16 +23,11 @@ class Rundoc::CodeCommand::FileCommand
       end
       @io = io
       @render_command = render_command
-      @render_result = render_result
       @contents = contents.dup if contents && !contents.empty?
     end
 
     def render_command?
       @render_command
-    end
-
-    def render_result?
-      @render_result
     end
 
     def to_md(env)

--- a/lib/rundoc/code_command/file_command/append.rb
+++ b/lib/rundoc/code_command/file_command/append.rb
@@ -23,7 +23,7 @@ class Rundoc::CodeCommand::FileCommand
     def to_md(env)
       return unless render_command?
 
-      if env[:commands].any? { |c| c[:object].not_hidden? }
+      if env[:commands].any? { |c| c[:visibility].not_hidden? }
         raise "Must call append in its own code section"
       end
 

--- a/lib/rundoc/code_command/file_command/append.rb
+++ b/lib/rundoc/code_command/file_command/append.rb
@@ -9,15 +9,30 @@ class Rundoc::CodeCommand::FileCommand
     end
   end
 
-  class AppendRunner < Rundoc::CodeCommand
-    include FileUtil
+  class AppendRunner
+    NEWLINE = Rundoc::CodeCommand::WriteRunner::NEWLINE
 
-    def initialize(user_args:, **)
+    include Rundoc::CodeCommand::FileUtil
+
+    attr_reader :io, :contents
+
+    def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
       @filename, line = user_args.filename.split("#")
       @line_number = if line
         Integer(line)
       end
-      super(**)
+      @io = io
+      @render_command = render_command
+      @render_result = render_result
+      @contents = contents.dup if contents && !contents.empty?
+    end
+
+    def render_command?
+      @render_command
+    end
+
+    def render_result?
+      @render_result
     end
 
     def to_md(env)

--- a/lib/rundoc/code_command/file_command/remove.rb
+++ b/lib/rundoc/code_command/file_command/remove.rb
@@ -9,9 +9,7 @@ class Rundoc::CodeCommand::FileCommand
     end
   end
 
-  class RemoveRunner < Rundoc::CodeCommand
-    # Newlines are stripped and re-added, this tells the project that
-    # we're intentionally wanting an extra newline
+  class RemoveRunner
     NEWLINE = Object.new
     def NEWLINE.to_s
       ""
@@ -20,11 +18,24 @@ class Rundoc::CodeCommand::FileCommand
     def NEWLINE.empty?
       false
     end
-    include FileUtil
+    include Rundoc::CodeCommand::FileUtil
 
-    def initialize(user_args:, **)
+    attr_reader :io, :contents
+
+    def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
       @filename = user_args.filename
-      super(**)
+      @io = io
+      @render_command = render_command
+      @render_result = render_result
+      @contents = contents.dup if contents && !contents.empty?
+    end
+
+    def render_command?
+      @render_command
+    end
+
+    def render_result?
+      @render_result
     end
 
     def to_md(env)

--- a/lib/rundoc/code_command/file_command/remove.rb
+++ b/lib/rundoc/code_command/file_command/remove.rb
@@ -28,7 +28,7 @@ class Rundoc::CodeCommand::FileCommand
     end
 
     def to_md(env)
-      if env[:commands].any? { |c| c[:object].not_hidden? }
+      if env[:commands].any? { |c| c[:visibility].not_hidden? }
         raise "Must call remove in its own code section"
       end
 

--- a/lib/rundoc/code_command/file_command/remove.rb
+++ b/lib/rundoc/code_command/file_command/remove.rb
@@ -25,17 +25,7 @@ class Rundoc::CodeCommand::FileCommand
     def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
       @filename = user_args.filename
       @io = io
-      @render_command = render_command
-      @render_result = render_result
       @contents = contents.dup if contents && !contents.empty?
-    end
-
-    def render_command?
-      @render_command
-    end
-
-    def render_result?
-      @render_result
     end
 
     def to_md(env)

--- a/lib/rundoc/code_command/file_command/remove.rb
+++ b/lib/rundoc/code_command/file_command/remove.rb
@@ -22,7 +22,7 @@ class Rundoc::CodeCommand::FileCommand
 
     attr_reader :io, :contents
 
-    def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
+    def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
       @filename = user_args.filename
       @io = io
       @render_command = render_command

--- a/lib/rundoc/code_command/no_such_command.rb
+++ b/lib/rundoc/code_command/no_such_command.rb
@@ -2,9 +2,18 @@
 
 module Rundoc
   class CodeCommand
-    class NoSuchCommand < Rundoc::CodeCommand
-      def initialize(user_args: nil, **)
-        super(**)
+    class NoSuchCommand
+      def initialize(user_args: nil, render_command: false, render_result: false, io: nil, contents: nil, **)
+        @render_command = render_command
+        @render_result = render_result
+      end
+
+      def render_command?
+        @render_command
+      end
+
+      def render_result?
+        @render_result
       end
 
       def call(env = {})

--- a/lib/rundoc/code_command/no_such_command.rb
+++ b/lib/rundoc/code_command/no_such_command.rb
@@ -4,16 +4,6 @@ module Rundoc
   module CodeCommand
     class NoSuchCommand
       def initialize(user_args: nil, render_command: false, render_result: false, io: nil, contents: nil)
-        @render_command = render_command
-        @render_result = render_result
-      end
-
-      def render_command?
-        @render_command
-      end
-
-      def render_result?
-        @render_result
       end
 
       def call(env = {})

--- a/lib/rundoc/code_command/no_such_command.rb
+++ b/lib/rundoc/code_command/no_such_command.rb
@@ -3,7 +3,7 @@
 module Rundoc
   module CodeCommand
     class NoSuchCommand
-      def initialize(user_args: nil, render_command: false, render_result: false, io: nil, contents: nil, **)
+      def initialize(user_args: nil, render_command: false, render_result: false, io: nil, contents: nil)
         @render_command = render_command
         @render_result = render_result
       end

--- a/lib/rundoc/code_command/no_such_command.rb
+++ b/lib/rundoc/code_command/no_such_command.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Rundoc
-  class CodeCommand
+  module CodeCommand
     class NoSuchCommand
       def initialize(user_args: nil, render_command: false, render_result: false, io: nil, contents: nil, **)
         @render_command = render_command

--- a/lib/rundoc/code_command/pipe.rb
+++ b/lib/rundoc/code_command/pipe.rb
@@ -15,8 +15,6 @@ module Rundoc
 
       def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
         @io = io
-        @render_command = render_command
-        @render_result = render_result
         @delegate = parse(user_args.line)
       end
 
@@ -30,14 +28,6 @@ module Rundoc
 
         @delegate.push(last_command[:output])
         @delegate.build(io: io).call(env)
-      end
-
-      def render_command?
-        @render_command
-      end
-
-      def render_result?
-        @render_result
       end
 
       def to_md(env = {})

--- a/lib/rundoc/code_command/pipe.rb
+++ b/lib/rundoc/code_command/pipe.rb
@@ -13,7 +13,7 @@ module Rundoc
     class PipeRunner
       attr_reader :io
 
-      def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
+      def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
         @io = io
         @render_command = render_command
         @render_result = render_result

--- a/lib/rundoc/code_command/pipe.rb
+++ b/lib/rundoc/code_command/pipe.rb
@@ -10,9 +10,13 @@ module Rundoc
       end
     end
 
-    class PipeRunner < Rundoc::CodeCommand
-      def initialize(user_args:, **)
-        super(**)
+    class PipeRunner
+      attr_reader :io
+
+      def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
+        @io = io
+        @render_command = render_command
+        @render_result = render_result
         @delegate = parse(user_args.line)
       end
 
@@ -26,6 +30,14 @@ module Rundoc
 
         @delegate.push(last_command[:output])
         @delegate.build(io: io).call(env)
+      end
+
+      def render_command?
+        @render_command
+      end
+
+      def render_result?
+        @render_result
       end
 
       def to_md(env = {})

--- a/lib/rundoc/code_command/pipe.rb
+++ b/lib/rundoc/code_command/pipe.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Rundoc
-  class CodeCommand
+  module CodeCommand
     class PipeArgs
       attr_reader :line
 

--- a/lib/rundoc/code_command/pre/erb.rb
+++ b/lib/rundoc/code_command/pre/erb.rb
@@ -2,7 +2,7 @@
 
 require_relative "../print/erb"
 
-class Rundoc::CodeCommand
+module Rundoc::CodeCommand
   class PreErbArgs
     attr_reader :line
 

--- a/lib/rundoc/code_command/pre/erb.rb
+++ b/lib/rundoc/code_command/pre/erb.rb
@@ -11,8 +11,10 @@ class Rundoc::CodeCommand
     end
   end
 
-  class PreErbRunner < Rundoc::CodeCommand
-    def initialize(user_args:, render_command:, render_result:, **)
+  class PreErbRunner
+    attr_reader :io, :contents
+
+    def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
       @line = user_args.line
       @binding = RUNDOC_ERB_BINDINGS[RUNDOC_DEFAULT_ERB_BINDING]
       @code = nil
@@ -20,7 +22,18 @@ class Rundoc::CodeCommand
       @template = nil
       @render_delegate_result = render_result
       @render_delegate_command = render_command
-      super(render_command: false, render_result: false, **)
+      @io = io
+      @render_command = false
+      @render_result = false
+      @contents = contents.dup if contents && !contents.empty?
+    end
+
+    def render_command?
+      @render_command
+    end
+
+    def render_result?
+      @render_result
     end
 
     def code

--- a/lib/rundoc/code_command/pre/erb.rb
+++ b/lib/rundoc/code_command/pre/erb.rb
@@ -20,11 +20,9 @@ module Rundoc::CodeCommand
       @code = nil
       @command = nil
       @template = nil
-      @render_delegate_result = render_result
-      @render_delegate_command = render_command
+      @render_command = render_command
+      @render_result = render_result
       @io = io
-      @render_command = false
-      @render_result = false
       @contents = contents.dup if contents && !contents.empty?
     end
 
@@ -39,8 +37,8 @@ module Rundoc::CodeCommand
     def code
       @code ||= begin
         vis = +""
-        vis += @render_delegate_command ? ">" : "-"
-        vis += @render_delegate_result ? ">" : "-"
+        vis += render_command? ? ">" : "-"
+        vis += render_result? ? ">" : "-"
         code = [@line, @contents]
           .compact
           .reject(&:empty?)
@@ -72,4 +70,4 @@ module Rundoc::CodeCommand
     end
   end
 end
-Rundoc.register_code_command(keyword: :"pre.erb", args_klass: Rundoc::CodeCommand::PreErbArgs, runner_klass: Rundoc::CodeCommand::PreErbRunner)
+Rundoc.register_code_command(keyword: :"pre.erb", args_klass: Rundoc::CodeCommand::PreErbArgs, runner_klass: Rundoc::CodeCommand::PreErbRunner, always_hidden: true)

--- a/lib/rundoc/code_command/pre/erb.rb
+++ b/lib/rundoc/code_command/pre/erb.rb
@@ -14,7 +14,7 @@ module Rundoc::CodeCommand
   class PreErbRunner
     attr_reader :io, :contents
 
-    def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
+    def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
       @line = user_args.line
       @binding = RUNDOC_ERB_BINDINGS[RUNDOC_DEFAULT_ERB_BINDING]
       @code = nil

--- a/lib/rundoc/code_command/print/erb.rb
+++ b/lib/rundoc/code_command/print/erb.rb
@@ -12,7 +12,7 @@ class EmptyBinding
   end
 end
 
-class Rundoc::CodeCommand
+module Rundoc::CodeCommand
   RUNDOC_ERB_BINDINGS = Hash.new { |h, k| h[k] = EmptyBinding.create }
   RUNDOC_DEFAULT_ERB_BINDING = "default"
 

--- a/lib/rundoc/code_command/print/erb.rb
+++ b/lib/rundoc/code_command/print/erb.rb
@@ -28,7 +28,7 @@ module Rundoc::CodeCommand
   class PrintERBRunner
     attr_reader :contents
 
-    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil, **)
+    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil)
       @line = user_args.line
       @binding = RUNDOC_ERB_BINDINGS[user_args.binding_name]
       @render_command = render_command

--- a/lib/rundoc/code_command/print/erb.rb
+++ b/lib/rundoc/code_command/print/erb.rb
@@ -25,11 +25,23 @@ class Rundoc::CodeCommand
     end
   end
 
-  class PrintERBRunner < Rundoc::CodeCommand
-    def initialize(user_args:, **)
+  class PrintERBRunner
+    attr_reader :contents
+
+    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil, **)
       @line = user_args.line
       @binding = RUNDOC_ERB_BINDINGS[user_args.binding_name]
-      super(**)
+      @render_command = render_command
+      @render_result = render_result
+      @contents = contents.dup if contents && !contents.empty?
+    end
+
+    def render_command?
+      @render_command
+    end
+
+    def render_result?
+      @render_result
     end
 
     def to_md(env)

--- a/lib/rundoc/code_command/print/text.rb
+++ b/lib/rundoc/code_command/print/text.rb
@@ -12,7 +12,7 @@ module Rundoc::CodeCommand
   class PrintTextRunner
     attr_reader :contents
 
-    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil, **)
+    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil)
       @line = user_args.line
       @render_command = render_command
       @render_result = render_result

--- a/lib/rundoc/code_command/print/text.rb
+++ b/lib/rundoc/code_command/print/text.rb
@@ -23,10 +23,6 @@ class Rundoc::CodeCommand
       ""
     end
 
-    def hidden?
-      !render_result?
-    end
-
     def call(env = {})
       if render_before?
         ""

--- a/lib/rundoc/code_command/print/text.rb
+++ b/lib/rundoc/code_command/print/text.rb
@@ -9,10 +9,22 @@ class Rundoc::CodeCommand
     end
   end
 
-  class PrintTextRunner < Rundoc::CodeCommand
-    def initialize(user_args:, **)
+  class PrintTextRunner
+    attr_reader :contents
+
+    def initialize(user_args:, render_command:, render_result:, io: nil, contents: nil, **)
       @line = user_args.line
-      super(**)
+      @render_command = render_command
+      @render_result = render_result
+      @contents = contents.dup if contents && !contents.empty?
+    end
+
+    def render_command?
+      @render_command
+    end
+
+    def render_result?
+      @render_result
     end
 
     def to_md(env)

--- a/lib/rundoc/code_command/print/text.rb
+++ b/lib/rundoc/code_command/print/text.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Rundoc::CodeCommand
+module Rundoc::CodeCommand
   class PrintTextArgs
     attr_reader :line
 

--- a/lib/rundoc/code_command/raw.rb
+++ b/lib/rundoc/code_command/raw.rb
@@ -11,9 +11,21 @@ module Rundoc
     #   gem 'sqlite3'       <- parsed as Raw
     #   :::>> $ echo "hi"   <- parsed as a code command
     #   ```
-    class Raw < CodeCommand
-      def initialize(user_args: nil, **)
-        super(**)
+    class Raw
+      attr_reader :contents
+
+      def initialize(user_args: nil, render_command: true, render_result: true, io: nil, contents: nil, **)
+        @render_command = render_command
+        @render_result = render_result
+        @contents = contents.dup if contents && !contents.empty?
+      end
+
+      def render_command?
+        @render_command
+      end
+
+      def render_result?
+        @render_result
       end
 
       def call(env = {})

--- a/lib/rundoc/code_command/raw.rb
+++ b/lib/rundoc/code_command/raw.rb
@@ -15,17 +15,7 @@ module Rundoc
       attr_reader :contents
 
       def initialize(user_args: nil, render_command: true, render_result: true, io: nil, contents: nil)
-        @render_command = render_command
-        @render_result = render_result
         @contents = contents.dup if contents && !contents.empty?
-      end
-
-      def render_command?
-        @render_command
-      end
-
-      def render_result?
-        @render_result
       end
 
       def call(env = {})

--- a/lib/rundoc/code_command/raw.rb
+++ b/lib/rundoc/code_command/raw.rb
@@ -12,9 +12,8 @@ module Rundoc
     #   :::>> $ echo "hi"   <- parsed as a code command
     #   ```
     class Raw < CodeCommand
-      def initialize(contents, visible: true)
-        @contents = contents
-        @render_result = visible
+      def initialize(user_args: nil, **)
+        super(**)
       end
 
       def call(env = {})

--- a/lib/rundoc/code_command/raw.rb
+++ b/lib/rundoc/code_command/raw.rb
@@ -14,7 +14,7 @@ module Rundoc
     class Raw
       attr_reader :contents
 
-      def initialize(user_args: nil, render_command: true, render_result: true, io: nil, contents: nil, **)
+      def initialize(user_args: nil, render_command: true, render_result: true, io: nil, contents: nil)
         @render_command = render_command
         @render_result = render_result
         @contents = contents.dup if contents && !contents.empty?

--- a/lib/rundoc/code_command/raw.rb
+++ b/lib/rundoc/code_command/raw.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Rundoc
-  class CodeCommand
+  module CodeCommand
     # Wraps lines inside a fenced code block that are not rundoc commands.
     # These are rendered as-is without executing any code.
     #

--- a/lib/rundoc/code_command/raw.rb
+++ b/lib/rundoc/code_command/raw.rb
@@ -2,6 +2,15 @@
 
 module Rundoc
   class CodeCommand
+    # Wraps lines inside a fenced code block that are not rundoc commands.
+    # These are rendered as-is without executing any code.
+    #
+    # Example:
+    #
+    #   ```ruby
+    #   gem 'sqlite3'       <- parsed as Raw
+    #   :::>> $ echo "hi"   <- parsed as a code command
+    #   ```
     class Raw < CodeCommand
       def initialize(contents, visible: true)
         @contents = contents

--- a/lib/rundoc/code_command/rundoc/require.rb
+++ b/lib/rundoc/code_command/rundoc/require.rb
@@ -11,10 +11,22 @@ class ::Rundoc::CodeCommand
       end
     end
 
-    class RequireRunner < ::Rundoc::CodeCommand
-      def initialize(user_args:, **)
+    class RequireRunner
+      attr_reader :io
+
+      def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
         @path = user_args.path
-        super(**)
+        @io = io
+        @render_command = render_command
+        @render_result = render_result
+      end
+
+      def render_command?
+        @render_command
+      end
+
+      def render_result?
+        @render_result
       end
 
       def to_md(env = {})

--- a/lib/rundoc/code_command/rundoc/require.rb
+++ b/lib/rundoc/code_command/rundoc/require.rb
@@ -45,14 +45,6 @@ class ::Rundoc::CodeCommand
 
         ""
       end
-
-      def hidden?
-        !render_result?
-      end
-
-      def not_hidden?
-        !hidden?
-      end
     end
   end
 end

--- a/lib/rundoc/code_command/rundoc/require.rb
+++ b/lib/rundoc/code_command/rundoc/require.rb
@@ -17,12 +17,7 @@ module ::Rundoc::CodeCommand
       def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
         @path = user_args.path
         @io = io
-        @render_command = render_command
         @render_result = render_result
-      end
-
-      def render_command?
-        @render_command
       end
 
       def render_result?

--- a/lib/rundoc/code_command/rundoc/require.rb
+++ b/lib/rundoc/code_command/rundoc/require.rb
@@ -14,7 +14,7 @@ module ::Rundoc::CodeCommand
     class RequireRunner
       attr_reader :io
 
-      def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
+      def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
         @path = user_args.path
         @io = io
         @render_command = render_command

--- a/lib/rundoc/code_command/rundoc/require.rb
+++ b/lib/rundoc/code_command/rundoc/require.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ::Rundoc::CodeCommand
+module ::Rundoc::CodeCommand
   class RundocCommand
     class RequireArgs
       attr_reader :path

--- a/lib/rundoc/code_command/rundoc_command.rb
+++ b/lib/rundoc/code_command/rundoc_command.rb
@@ -10,10 +10,23 @@ module ::Rundoc
       end
     end
 
-    class RundocCommandRunner < ::Rundoc::CodeCommand
-      def initialize(user_args:, **)
-        super(**)
-        @contents = user_args.code + @contents
+    class RundocCommandRunner
+      attr_reader :io, :contents
+
+      def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
+        @io = io
+        @render_command = render_command
+        @render_result = render_result
+        @contents = contents.dup if contents && !contents.empty?
+        @contents = user_args.code + (@contents || +"")
+      end
+
+      def render_command?
+        @render_command
+      end
+
+      def render_result?
+        @render_result
       end
 
       def to_md(env = {})

--- a/lib/rundoc/code_command/rundoc_command.rb
+++ b/lib/rundoc/code_command/rundoc_command.rb
@@ -13,7 +13,7 @@ module ::Rundoc
     class RundocCommandRunner
       attr_reader :io, :contents
 
-      def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
+      def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
         @io = io
         @render_command = render_command
         @render_result = render_result

--- a/lib/rundoc/code_command/rundoc_command.rb
+++ b/lib/rundoc/code_command/rundoc_command.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ::Rundoc
-  class CodeCommand
+  module CodeCommand
     class RundocCommandArgs
       attr_reader :code
 

--- a/lib/rundoc/code_command/rundoc_command.rb
+++ b/lib/rundoc/code_command/rundoc_command.rb
@@ -15,18 +15,8 @@ module ::Rundoc
 
       def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
         @io = io
-        @render_command = render_command
-        @render_result = render_result
         @contents = contents.dup if contents && !contents.empty?
         @contents = user_args.code + (@contents || +"")
-      end
-
-      def render_command?
-        @render_command
-      end
-
-      def render_result?
-        @render_result
       end
 
       def to_md(env = {})

--- a/lib/rundoc/code_command/website/navigate.rb
+++ b/lib/rundoc/code_command/website/navigate.rb
@@ -12,7 +12,7 @@ class Rundoc::CodeCommand::Website
   class NavigateRunner
     attr_reader :io, :contents
 
-    def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
+    def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
       @name = user_args.name
       @driver = nil
       @io = io

--- a/lib/rundoc/code_command/website/navigate.rb
+++ b/lib/rundoc/code_command/website/navigate.rb
@@ -16,17 +16,7 @@ class Rundoc::CodeCommand::Website
       @name = user_args.name
       @driver = nil
       @io = io
-      @render_command = render_command
-      @render_result = render_result
       @contents = contents.dup if contents && !contents.empty?
-    end
-
-    def render_command?
-      @render_command
-    end
-
-    def render_result?
-      @render_result
     end
 
     def driver

--- a/lib/rundoc/code_command/website/navigate.rb
+++ b/lib/rundoc/code_command/website/navigate.rb
@@ -29,14 +29,6 @@ class Rundoc::CodeCommand::Website
       driver.safe_eval(contents, env)
       ""
     end
-
-    def hidden?
-      true
-    end
-
-    def not_hidden?
-      !hidden?
-    end
   end
 end
 

--- a/lib/rundoc/code_command/website/navigate.rb
+++ b/lib/rundoc/code_command/website/navigate.rb
@@ -9,11 +9,24 @@ class Rundoc::CodeCommand::Website
     end
   end
 
-  class NavigateRunner < Rundoc::CodeCommand
-    def initialize(user_args:, **)
+  class NavigateRunner
+    attr_reader :io, :contents
+
+    def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
       @name = user_args.name
       @driver = nil
-      super(**)
+      @io = io
+      @render_command = render_command
+      @render_result = render_result
+      @contents = contents.dup if contents && !contents.empty?
+    end
+
+    def render_command?
+      @render_command
+    end
+
+    def render_result?
+      @render_result
     end
 
     def driver

--- a/lib/rundoc/code_command/website/screenshot.rb
+++ b/lib/rundoc/code_command/website/screenshot.rb
@@ -13,7 +13,7 @@ class Rundoc::CodeCommand::Website
   class ScreenshotRunner
     attr_reader :io
 
-    def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
+    def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
       @name = user_args.name
       @upload = user_args.upload
       @driver = nil

--- a/lib/rundoc/code_command/website/screenshot.rb
+++ b/lib/rundoc/code_command/website/screenshot.rb
@@ -18,16 +18,6 @@ class Rundoc::CodeCommand::Website
       @upload = user_args.upload
       @driver = nil
       @io = io
-      @render_command = render_command
-      @render_result = render_result
-    end
-
-    def render_command?
-      @render_command
-    end
-
-    def render_result?
-      @render_result
     end
 
     def driver

--- a/lib/rundoc/code_command/website/screenshot.rb
+++ b/lib/rundoc/code_command/website/screenshot.rb
@@ -37,14 +37,6 @@ class Rundoc::CodeCommand::Website
       env[:before] << "![Screenshot of #{driver.current_url}](#{relative_filename})"
       ""
     end
-
-    # def hidden?
-    #   true
-    # end
-
-    # def not_hidden?
-    #   !hidden?
-    # end
   end
 end
 Rundoc.register_code_command(keyword: :"website.screenshot", args_klass: Rundoc::CodeCommand::Website::ScreenshotArgs, runner_klass: Rundoc::CodeCommand::Website::ScreenshotRunner)

--- a/lib/rundoc/code_command/website/screenshot.rb
+++ b/lib/rundoc/code_command/website/screenshot.rb
@@ -10,12 +10,24 @@ class Rundoc::CodeCommand::Website
     end
   end
 
-  class ScreenshotRunner < Rundoc::CodeCommand
-    def initialize(user_args:, **)
+  class ScreenshotRunner
+    attr_reader :io
+
+    def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
       @name = user_args.name
       @upload = user_args.upload
       @driver = nil
-      super(**)
+      @io = io
+      @render_command = render_command
+      @render_result = render_result
+    end
+
+    def render_command?
+      @render_command
+    end
+
+    def render_result?
+      @render_result
     end
 
     def driver

--- a/lib/rundoc/code_command/website/visit.rb
+++ b/lib/rundoc/code_command/website/visit.rb
@@ -18,7 +18,7 @@ class Rundoc::CodeCommand::Website
   class VisitRunner
     attr_reader :io, :contents
 
-    def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
+    def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
       @name = user_args.name
       @url = user_args.url
       @scroll = user_args.scroll

--- a/lib/rundoc/code_command/website/visit.rb
+++ b/lib/rundoc/code_command/website/visit.rb
@@ -27,17 +27,7 @@ class Rundoc::CodeCommand::Website
       @visible = user_args.visible
       @max_attempts = user_args.max_attempts
       @io = io
-      @render_command = render_command
-      @render_result = render_result
       @contents = contents.dup if contents && !contents.empty?
-    end
-
-    def render_command?
-      @render_command
-    end
-
-    def render_result?
-      @render_result
     end
 
     def driver

--- a/lib/rundoc/code_command/website/visit.rb
+++ b/lib/rundoc/code_command/website/visit.rb
@@ -58,14 +58,6 @@ class Rundoc::CodeCommand::Website
 
       ""
     end
-
-    def hidden?
-      true
-    end
-
-    def not_hidden?
-      !hidden?
-    end
   end
 end
 

--- a/lib/rundoc/code_command/website/visit.rb
+++ b/lib/rundoc/code_command/website/visit.rb
@@ -15,8 +15,10 @@ class Rundoc::CodeCommand::Website
     end
   end
 
-  class VisitRunner < Rundoc::CodeCommand
-    def initialize(user_args:, **)
+  class VisitRunner
+    attr_reader :io, :contents
+
+    def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
       @name = user_args.name
       @url = user_args.url
       @scroll = user_args.scroll
@@ -24,7 +26,18 @@ class Rundoc::CodeCommand::Website
       @width = user_args.width
       @visible = user_args.visible
       @max_attempts = user_args.max_attempts
-      super(**)
+      @io = io
+      @render_command = render_command
+      @render_result = render_result
+      @contents = contents.dup if contents && !contents.empty?
+    end
+
+    def render_command?
+      @render_command
+    end
+
+    def render_result?
+      @render_result
     end
 
     def driver

--- a/lib/rundoc/code_command/write.rb
+++ b/lib/rundoc/code_command/write.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Rundoc
-  class CodeCommand
+  module CodeCommand
     module FileUtil
       def filename
         files = Dir.glob(@filename)

--- a/lib/rundoc/code_command/write.rb
+++ b/lib/rundoc/code_command/write.rb
@@ -46,7 +46,7 @@ module Rundoc
 
       def to_md(env)
         if render_command?
-          if env[:commands].any? { |c| c[:object].not_hidden? }
+          if env[:commands].any? { |c| c[:visibility].not_hidden? }
             raise "must call write in its own code section"
           end
           env[:before] << "In file `#{filename}` write:"

--- a/lib/rundoc/code_command/write.rb
+++ b/lib/rundoc/code_command/write.rb
@@ -43,16 +43,11 @@ module Rundoc
         @filename = user_args.path.to_s
         @io = io
         @render_command = render_command
-        @render_result = render_result
         @contents = contents.dup if contents && !contents.empty?
       end
 
       def render_command?
         @render_command
-      end
-
-      def render_result?
-        @render_result
       end
 
       def to_md(env)

--- a/lib/rundoc/code_command/write.rb
+++ b/lib/rundoc/code_command/write.rb
@@ -25,9 +25,7 @@ module Rundoc
       end
     end
 
-    class WriteRunner < Rundoc::CodeCommand
-      # Newlines are stripped and re-added, this tells the project that
-      # we're intentionally wanting an extra newline
+    class WriteRunner
       NEWLINE = Object.new
       def NEWLINE.to_s
         ""
@@ -37,11 +35,24 @@ module Rundoc
         false
       end
 
-      include FileUtil
+      include Rundoc::CodeCommand::FileUtil
 
-      def initialize(user_args:, **)
+      attr_reader :io, :contents
+
+      def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
         @filename = user_args.path.to_s
-        super(**)
+        @io = io
+        @render_command = render_command
+        @render_result = render_result
+        @contents = contents.dup if contents && !contents.empty?
+      end
+
+      def render_command?
+        @render_command
+      end
+
+      def render_result?
+        @render_result
       end
 
       def to_md(env)

--- a/lib/rundoc/code_command/write.rb
+++ b/lib/rundoc/code_command/write.rb
@@ -39,7 +39,7 @@ module Rundoc
 
       attr_reader :io, :contents
 
-      def initialize(user_args:, render_command:, render_result:, io:, contents: nil, **)
+      def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
         @filename = user_args.path.to_s
         @io = io
         @render_command = render_command

--- a/lib/rundoc/fenced_code_block.rb
+++ b/lib/rundoc/fenced_code_block.rb
@@ -56,16 +56,20 @@ module Rundoc
       env[:context] = @context
       env[:stack] = @stack
 
+      any_visible = false
+
       while (item = @stack.pop)
         code_command = item.build(io: @io)
 
         code_output = code_command.call(env) || ""
         code_line = code_command.to_md(env) || ""
-        result << code_line if code_command.render_command?
-        result << code_output if code_command.render_result?
+        result << code_line if item.render_command?
+        result << code_output if item.render_result?
 
         PARTIAL_RESULT.replace(result)
         PARTIAL_ENV.replace(env)
+
+        any_visible = true if item.not_hidden?
 
         env[:commands] << {
           object: code_command,
@@ -74,7 +78,7 @@ module Rundoc
         }
       end
 
-      if env[:commands].any? { |c| c[:object].not_hidden? }
+      if any_visible
         @rendered = self.class.to_doc(result: result, env: env)
       end
       self

--- a/lib/rundoc/fenced_code_block.rb
+++ b/lib/rundoc/fenced_code_block.rb
@@ -15,7 +15,7 @@ module Rundoc
     def executed_commands
       raise "Nothing executed" unless @env[:commands].any?
 
-      @env[:commands].map { |c| c[:object] }
+      @env[:commands].map { |c| c[:visibility] }
     end
 
     # @param fence [String] the fence used to start the code block like "```".

--- a/lib/rundoc/fenced_code_block.rb
+++ b/lib/rundoc/fenced_code_block.rb
@@ -57,11 +57,7 @@ module Rundoc
       env[:stack] = @stack
 
       while (item = @stack.pop)
-        code_command = if item.is_a?(CodeCommand::Deferred)
-          item.build(io: @io)
-        else
-          item
-        end
+        code_command = item.build(io: @io)
 
         code_output = code_command.call(env) || ""
         code_line = code_command.to_md(env) || ""

--- a/lib/rundoc/fenced_code_block.rb
+++ b/lib/rundoc/fenced_code_block.rb
@@ -55,9 +55,6 @@ module Rundoc
       env[:after] = []
       env[:context] = @context
       env[:stack] = @stack
-
-      any_visible = false
-
       while (item = @stack.pop)
         code_command = item.build(io: @io)
 
@@ -69,16 +66,15 @@ module Rundoc
         PARTIAL_RESULT.replace(result)
         PARTIAL_ENV.replace(env)
 
-        any_visible = true if item.not_hidden?
-
         env[:commands] << {
           object: code_command,
           output: code_output,
-          command: code_line
+          command: code_line,
+          visibility: item
         }
       end
 
-      if any_visible
+      if env[:commands].any? { |c| c[:visibility].not_hidden? }
         @rendered = self.class.to_doc(result: result, env: env)
       end
       self

--- a/lib/rundoc/peg_parser.rb
+++ b/lib/rundoc/peg_parser.rb
@@ -267,16 +267,21 @@ module Rundoc
       code_command
     }
 
-    # The lines before a CodeCommand are rendered
-    # without running any code
     rule(raw_code: simple(:raw_code)) {
-      CodeCommand::Raw.new(raw_code)
+      deferred = CodeCommand::Deferred.new(args_instance: nil, runner_klass: CodeCommand::Raw)
+      deferred.render_command = false
+      deferred.render_result = true
+      deferred.push(raw_code.to_s)
+      deferred
     }
 
-    # Sometimes
     rule(raw_code: sequence(:raw_code)) {
-      hidden = raw_code.nil? || raw_code.empty?
-      CodeCommand::Raw.new(raw_code, visible: !hidden)
+      visible = !raw_code.nil? && !raw_code.empty?
+      deferred = CodeCommand::Deferred.new(args_instance: nil, runner_klass: CodeCommand::Raw)
+      deferred.render_command = false
+      deferred.render_result = visible
+      deferred.push(raw_code.map(&:to_s).join)
+      deferred
     }
   end
 end


### PR DESCRIPTION
Before, runner classes inherited from a base class that didn't do much. It saved a little code, but provided functionality not strictly needed in a runner. This code change gets rid of that base class and makes each runner class easier to reason about locally without needing to also know what it inherits.