### PR TITLE
Fix seattle_method matching across newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added comment syntax. Use an octothorpe (`#`) after the visibility markers to comment out any commands and make them a no-op.
 - Changed: Minimum Ruby version is now 3.2 (Ruby 3.1 reached EOL in March 2025).
 - Changed: All code commands now use an Args + Runner class pattern. `register_code_command` now requires keyword arguments: `keyword:`, `args_klass:`, and `runner_klass:`.
+- Fix: `seattle_method` parser rule no longer matches across newlines. Previously, a command with no same-line arguments (e.g. `:::>> rundoc`) would consume the next line as its argument, losing the newline between content lines. (https://github.com/zombocom/rundoc/pull/118)
 
 ## 4.1.4
 

--- a/lib/rundoc/code_command/print/text.rb
+++ b/lib/rundoc/code_command/print/text.rb
@@ -4,7 +4,7 @@ module Rundoc::CodeCommand
   class PrintTextArgs
     attr_reader :line
 
-    def initialize(line)
+    def initialize(line = nil)
       @line = line
     end
   end

--- a/lib/rundoc/peg_parser.rb
+++ b/lib/rundoc/peg_parser.rb
@@ -6,6 +6,7 @@ module Rundoc
   class PegParser < Parslet::Parser
     rule(:spaces) { match('\s').repeat(1) }
     rule(:spaces?) { spaces.maybe }
+    rule(:horizontal_spaces) { match('[ \t]').repeat(1) }
     rule(:comma) { spaces? >> str(",") >> spaces? }
     rule(:digit) { match("[0-9]") }
     rule(:lparen) { str("(") >> spaces? }
@@ -89,7 +90,7 @@ module Rundoc
     }
 
     rule(:seattle_method) {
-      funcall >> spaces >>
+      funcall >> horizontal_spaces >>
         args.as(:args)
     }
 

--- a/test/rundoc/peg_parser_test.rb
+++ b/test/rundoc/peg_parser_test.rb
@@ -249,7 +249,8 @@ class PegParserTest < Minitest::Test
 
     actual = @transformer.apply(tree)
     assert_equal :rundoc, actual.keyword
-    assert_equal("email = ENV['HEROKU_EMAIL'] || `heroku auth:whoami`", actual.original_args)
+    assert_nil actual.original_args
+    assert_equal("email = ENV['HEROKU_EMAIL'] || `heroku auth:whoami`\n", actual.contents)
   end
 
   def test_rundoc_sub_commands_no_quotes

--- a/test/rundoc/peg_parser_test.rb
+++ b/test/rundoc/peg_parser_test.rb
@@ -351,4 +351,19 @@ class PegParserTest < Minitest::Test
     assert_equal :"background.start", actual.keyword
     assert_equal ["rails server", {name: "server"}], actual.original_args
   end
+
+  def test_no_args_preserves_newlines_in_stdin
+    input = <<~EOF.strip
+      :::>> rundoc
+      first = 1 # comment
+      second = 2
+    EOF
+
+    parser = Rundoc::PegParser.new.command_with_stdin
+    tree = parser.parse_with_debug(input)
+
+    actual = @transformer.apply(tree)
+    assert_equal :rundoc, actual.keyword
+    assert_equal "first = 1 # comment\nsecond = 2".strip, actual.contents.strip
+  end
 end


### PR DESCRIPTION
When ending a ruby line with a ruby comment

```
:::>> rundoc
ENV["TERM"] = "dumb" # https://github.com/heroku/cli/issues/3598
email = ENV['HEROKU_EMAIL'] || `heroku auth:whoami`
```

## Expected

The two lines are run one after the other.

## Actual

The two lines are concatenated such that the second line is treated as a Ruby comment

```
ENV["TERM"] = "dumb" # https://github.com/heroku/cli/issues/3598email = ENV['HEROKU_EMAIL'] || `heroku auth:whoami`
```

## Problem

When a `:::>> rundoc` command has no same-line arguments, the `seattle_method` parser rule's use of `spaces` (which matches `\s`, including `\n`) causes it to consume the newline after the command and match the next line as the command's argument. This means `seattle_method` wins the `method_call` alternation instead of falling through to `no_args_method`. 

Then the `command` rule's trailing `newline.maybe` eats the newline between that incorrectly-captured "argument" line and the remaining stdin. When `Deferred#push` concatenates the stdin, the newline is gone -- so `first = 1 # comment` and `second = 2` become `first = 1 # commentsecond = 2`, and the Ruby comment swallows the second assignment entirely.

## Fix

Introduce a `horizontal_spaces` rule matching only `[ \t]` (spaces and tabs, no newlines) and use it in `seattle_method` instead of `spaces`. This constrains `seattle_method` to only match arguments on the same line as the funcall, so when there are no same-line arguments, it fails, and parsing correctly falls through to `no_args_method`.
