### PR TITLE
Share binding context between rundoc and ERB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         ruby:
           - 3.2
           - 3.3
+          - 3.4
           - "4.0"
           - head
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Changed: The ruby context in `rundoc` and `rundoc.configure` commands is now the same binding as the default ERB evaluation. This means that methods can be defined in one and used in both.
+
 ## 5.0.0
 
 - Added comment syntax. Use an octothorpe (`#`) after the visibility markers to comment out any commands and make them a no-op.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ This will generate a project folder with your project in it, and a markdown `REA
   - [website.screenshot](#screenshots)
 - Configure RunDOC
   - [rundoc.configure](#configure)
+  - [rundoc](#configure) an alias for `rundoc.configure`
 - Import and compose documents
   - [rundoc.require](#compose-multiple-rundoc-documents)
 
@@ -616,13 +617,37 @@ If you need to specify project specific environment variables create a file call
 
 ## Configure
 
-You can configure your docs in your docs use the `RunDOC` command
+You can configure your docs in your docs use the `RunDOC` command via `rundoc.configure` (or alias `rundoc`):
 
     ```
     :::-- rundoc.configure
     ```
 
 Note: Make sure you run this as a hidden command (with `-`).
+
+This will give you a Ruby codeblock that executes and gives you access to `Rundoc.configure do |config|` to configure things about your build (such as modifying your markdown document after successful builds).
+
+**Define and Re-use logic**
+
+Since it's **just ruby** :tm: you can also use it to define shared logic that can be re-used in ERB templates. For example:
+
+      ```
+      :::-- rundoc
+      def run!(command, quiet: false, error_on_fail: true)
+        puts "Running `#{command}`" unless quiet
+        output = `#{command}`
+        puts "Command `#{command}` output:\n#{output}" unless quiet
+        if error_on_fail && !$?.success?
+          raise "Error running #{command}. Output:\n#{output}"
+        end
+        output
+      end
+      ```
+
+      ```
+      :::-> print.erb
+      Hello <%= run!("heroku whoami") %>!
+      ```
 
 **After Build**
 

--- a/lib/rundoc/code_command.rb
+++ b/lib/rundoc/code_command.rb
@@ -5,6 +5,7 @@ module Rundoc
   end
 end
 
+require "rundoc/code_command/empty_binding"
 require "rundoc/code_command/deferred"
 require "rundoc/code_command/bash"
 require "rundoc/code_command/pipe"

--- a/lib/rundoc/code_command/empty_binding.rb
+++ b/lib/rundoc/code_command/empty_binding.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "erb"
+
+class EmptyBinding
+  def self.create
+    new.empty_binding
+  end
+
+  def empty_binding
+    binding
+  end
+end
+
+module Rundoc::CodeCommand
+  RUNDOC_ERB_BINDINGS = Hash.new { |h, k| h[k] = EmptyBinding.create }
+  RUNDOC_DEFAULT_ERB_BINDING = "default"
+end

--- a/lib/rundoc/code_command/print/erb.rb
+++ b/lib/rundoc/code_command/print/erb.rb
@@ -1,21 +1,8 @@
 # frozen_string_literal: true
 
-require "erb"
-
-class EmptyBinding
-  def self.create
-    new.empty_binding
-  end
-
-  def empty_binding
-    binding
-  end
-end
+require_relative "../empty_binding"
 
 module Rundoc::CodeCommand
-  RUNDOC_ERB_BINDINGS = Hash.new { |h, k| h[k] = EmptyBinding.create }
-  RUNDOC_DEFAULT_ERB_BINDING = "default"
-
   class PrintERBArgs
     attr_reader :line, :binding_name
 

--- a/lib/rundoc/code_command/rundoc_command.rb
+++ b/lib/rundoc/code_command/rundoc_command.rb
@@ -17,6 +17,7 @@ module ::Rundoc
         @io = io
         @contents = contents.dup if contents && !contents.empty?
         @contents = user_args.code + (@contents || +"")
+        @binding = RUNDOC_ERB_BINDINGS[RUNDOC_DEFAULT_ERB_BINDING]
       end
 
       def to_md(env = {})
@@ -25,7 +26,7 @@ module ::Rundoc
 
       def call(env = {})
         io.puts "Running: #{contents}"
-        eval(contents) # rubocop:disable Security/Eval
+        eval(contents, @binding) # rubocop:disable Security/Eval
         ""
       end
     end

--- a/rundoc.gemspec
+++ b/rundoc.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "aws-sdk-s3", "~> 1"
   gem.add_dependency "dotenv"
+  gem.add_dependency "cgi", ">= 0.3.6"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "mocha"

--- a/test/integration/print_test.rb
+++ b/test/integration/print_test.rb
@@ -50,6 +50,57 @@ class IntegrationPrintTest < Minitest::Test
     end
   end
 
+  def test_rundoc_configure_defines_variable_accessible_from_erb
+    key = SecureRandom.hex
+    contents = <<~RUBY
+      ```
+      :::-- rundoc.configure
+      @shared_value = "#{key}"
+      ```
+
+      ```
+      :::-> print.erb
+      <%= @shared_value %>
+      ```
+    RUBY
+
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        parsed = parse_contents(contents)
+        actual = parsed.to_md.gsub(Rundoc::FencedCodeBlock::AUTOGEN_WARNING, "")
+        assert_includes actual, key
+      end
+    end
+  end
+
+  def test_erb_defines_variable_accessible_from_rundoc_configure
+    key = SecureRandom.hex
+    contents = <<~RUBY
+      ```
+      :::-> print.erb
+      <% @from_erb = "#{key}" %>
+      ```
+
+      ```
+      :::-- rundoc.configure
+      @roundtripped = @from_erb + "_via_configure"
+      ```
+
+      ```
+      :::-> print.erb
+      <%= @roundtripped %>
+      ```
+    RUBY
+
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        parsed = parse_contents(contents)
+        actual = parsed.to_md.gsub(Rundoc::FencedCodeBlock::AUTOGEN_WARNING, "")
+        assert_includes actual, "#{key}_via_configure"
+      end
+    end
+  end
+
   def test_erb_in_block
     contents = <<~RUBY
       ```


### PR DESCRIPTION
Previously, the eval in `rundoc.configure` was independent of the evaluation binding context in ERB blocks. This meant that code made in one could not be reused in another. With this change, developers can keep their code DRY-er.

      ```
      :::-- rundoc
      def run!(command, quiet: false, error_on_fail: true)
        puts "Running `#{command}`" unless quiet
        output = `#{command}`
        puts "Command `#{command}` output:\n#{output}" unless quiet
        if error_on_fail && !$?.success?
          raise "Error running #{command}. Output:\n#{output}"
        end
        output
      end
      ```

      ```
      :::-> print.erb
      Hello <%= run!("heroku whoami") %>!
      ```
