### PR TITLE
Add `rundoc.ensure_later` for cleaning up resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+- Added: `rundoc.ensure_later(dir: :cwd)` command to register cleanup blocks that run on every build (success and failure). Useful for guaranteed resource teardown (e.g., destroying Heroku apps). Multiple blocks execute in order; failures in one block do not stop the rest.
 - Changed: The ruby context in `rundoc` and `rundoc.configure` commands is now the same binding as the default ERB evaluation. This means that methods can be defined in one and used in both.
 
 ## 5.0.0

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ This will generate a project folder with your project in it, and a markdown `REA
   - [website.screenshot](#screenshots)
 - Configure RunDOC
   - [rundoc.configure](#configure)
+  - [rundoc.ensure_later](#ensure_later)
   - [rundoc](#configure) an alias for `rundoc.configure`
 - Import and compose documents
   - [rundoc.require](#compose-multiple-rundoc-documents)
@@ -682,6 +683,41 @@ Sometimes sensitive info like usernames, email addresses, or passwords may be in
     ```
 
 This command `filter_sensitive` can be called multiple times with different values. Since the config is in Ruby you could iterate over an array of sensitive data
+
+## Ensure Later
+
+Run a script on EVERY build (success and failure). Used to guarantee resources are cleaned up.
+
+- Arguments
+  - `dir:` The directory where the script will be run. Must be one of these values:
+    - `:cwd` The directory where the command is first invoked. If this directory does not exist when the `rundoc.ensure_later` is invoked, it will raise an error.
+    - `:rundoc_root` The tmp directory where the script is being executed. Useful if the directory where the `rundoc.ensure_later` is defined, is deleted by the rundoc script.
+
+For example:
+
+    ```
+    :::>> $ heroku create
+    :::-- rundoc
+    @app_name = run!("heroku info --json | jq -r '.app.name'").strip
+
+    def app_name
+      @app_name
+    end
+    ```
+
+    ```ruby
+    :::-- rundoc.ensure_later(dir: :cwd)
+    if run!("heroku apps").include?(app_name)
+      puts "Cleaning up web app #{app_name}"
+      run!("heroku apps:destroy #{app_name} --confirm #{app_name}")
+    else
+      puts "App `#{app_name}` already cleaned, nothing to do"
+    end
+    ```
+
+The output of this will not be included in the document. Multiple ensure blocks can be defined and will execute in the order of their definition. Since they'll be executed EVERY time, logic must handle both success and failure cases. This execution occurs before the temp directory is removed, and before any background task shutdown ensure blocks are triggered.
+
+If a build is successful, but an `ensure_later` block fails, the build will be considered a failure. A failure in one block will not stop the rest from executing.
 
 ## Writing a new command
 

--- a/lib/rundoc.rb
+++ b/lib/rundoc.rb
@@ -110,7 +110,9 @@ module Rundoc
     ensure_later_blocks.each do |block|
       io.puts "Running ensure_later block in #{block[:dir]}:\n#{block[:code]}"
       Dir.chdir(block[:dir]) do
-        eval(block[:code], block[:binding]) # rubocop:disable Security/Eval
+        capture_stdout_stderr(io) do
+          eval(block[:code], block[:binding]) # rubocop:disable Security/Eval
+        end
       end
     rescue => e
       io.puts "ensure_later block failed in #{block[:dir]}: #{e.message}"
@@ -119,6 +121,17 @@ module Rundoc
     end
     ensure_later_blocks.clear
     errors
+  end
+
+  def capture_stdout_stderr(io)
+    old_stdout = $stdout
+    old_stderr = $stderr
+    $stdout = io
+    $stderr = io
+    yield
+  ensure
+    $stdout = old_stdout
+    $stderr = old_stderr
   end
 
   def filter_sensitive(sensitive)

--- a/lib/rundoc.rb
+++ b/lib/rundoc.rb
@@ -97,6 +97,30 @@ module Rundoc
     yield self
   end
 
+  def ensure_later_blocks
+    @ensure_later_blocks ||= []
+  end
+
+  def add_ensure_later(dir:, code:, binding:)
+    ensure_later_blocks << {dir: dir, code: code, binding: binding}
+  end
+
+  def run_ensure_later(io:)
+    errors = []
+    ensure_later_blocks.each do |block|
+      io.puts "Running ensure_later block in #{block[:dir]}:\n#{block[:code]}"
+      Dir.chdir(block[:dir]) do
+        eval(block[:code], block[:binding]) # rubocop:disable Security/Eval
+      end
+    rescue => e
+      io.puts "ensure_later block failed in #{block[:dir]}: #{e.message}"
+      io.puts e.backtrace.join("\n")
+      errors << e
+    end
+    ensure_later_blocks.clear
+    errors
+  end
+
   def filter_sensitive(sensitive)
     raise "Expecting #{sensitive} to be a hash" unless sensitive.is_a?(Hash)
     @sensitive ||= {}

--- a/lib/rundoc/cli.rb
+++ b/lib/rundoc/cli.rb
@@ -135,6 +135,7 @@ module Rundoc
 
     def call
       build_success = false
+      ensure_later_errors = []
 
       io.puts "## Running your docs"
       load_dotenv
@@ -167,7 +168,11 @@ module Rundoc
           io: io
         )
         output = begin
-          parser.to_md
+          begin
+            parser.to_md
+          ensure
+            ensure_later_errors = Rundoc.run_ensure_later(io: io)
+          end
         rescue StandardError, SignalException => e
           io.puts "Received exception: #{e.inspect}, cleaning up before re-raise"
           on_fail
@@ -179,8 +184,6 @@ module Rundoc
 
       build_success = true
     ensure
-      ensure_later_errors = Rundoc.run_ensure_later(io: io)
-
       # Stop any hanging background tasks
       Rundoc::CodeCommand::Background::ProcessSpawn.tasks.each do |name, task|
         next unless task.alive?

--- a/lib/rundoc/cli.rb
+++ b/lib/rundoc/cli.rb
@@ -134,6 +134,8 @@ module Rundoc
     end
 
     def call
+      build_success = false
+
       io.puts "## Running your docs"
       load_dotenv
       check_directories_empty!
@@ -174,7 +176,11 @@ module Rundoc
 
         on_success(output)
       end
+
+      build_success = true
     ensure
+      ensure_later_errors = Rundoc.run_ensure_later(io: io)
+
       # Stop any hanging background tasks
       Rundoc::CodeCommand::Background::ProcessSpawn.tasks.each do |name, task|
         next unless task.alive?
@@ -188,6 +194,10 @@ module Rundoc
           dir: execution_context.output_dir,
           description: "tmp working directory"
         )
+      end
+
+      if ensure_later_errors.any? && build_success
+        raise ensure_later_errors.first
       end
     end
 

--- a/lib/rundoc/code_command/bash/cd.rb
+++ b/lib/rundoc/code_command/bash/cd.rb
@@ -7,7 +7,7 @@ class Rundoc::CodeCommand::BashRunner
       @line = line
     end
 
-    def supress_chdir_warning
+    def suppress_chdir_warning
       old_verbose = $VERBOSE
       $VERBOSE = nil
       yield
@@ -19,7 +19,7 @@ class Rundoc::CodeCommand::BashRunner
       line = @line.sub("cd", "").strip
       @io.puts "running $ cd #{line}"
 
-      supress_chdir_warning do
+      suppress_chdir_warning do
         Dir.chdir(line)
       end
 

--- a/lib/rundoc/code_command/bash/cd.rb
+++ b/lib/rundoc/code_command/bash/cd.rb
@@ -7,18 +7,12 @@ class Rundoc::CodeCommand::BashRunner
       @line = line
     end
 
-    # Ignore duplicate chdir warnings "warning: conflicting chdir during another chdir block"
     def supress_chdir_warning
-      old_stderr = $stderr
-      capture_stderr = StringIO.new
-      $stderr = capture_stderr
+      old_verbose = $VERBOSE
+      $VERBOSE = nil
       yield
     ensure
-      if old_stderr
-        $stderr = old_stderr
-        capture_string = capture_stderr.string
-        warn capture_string if capture_string.each_line.count > 1 || !capture_string.include?("conflicting chdir")
-      end
+      $VERBOSE = old_verbose
     end
 
     def call(env)

--- a/lib/rundoc/code_command/rundoc/ensure_later.rb
+++ b/lib/rundoc/code_command/rundoc/ensure_later.rb
@@ -3,16 +3,26 @@
 module ::Rundoc::CodeCommand
   class RundocCommand
     class EnsureLaterArgs
-      VALID_DIRS = [:cwd, :rundoc_root].freeze
-
-      attr_reader :dir
+      MAPPING = {
+        cwd: ->(context:) {
+          Dir.pwd
+        },
+        rundoc_root: ->(context:) {
+          context.output_dir.to_s
+        }
+      }.freeze
 
       def initialize(dir:)
-        dir = dir.to_sym
-        unless VALID_DIRS.include?(dir)
-          raise ArgumentError, "Invalid dir: #{dir.inspect}, must be one of: #{VALID_DIRS.map(&:inspect).join(", ")}"
-        end
         @dir = dir
+        @logic = MAPPING[dir] or raise ArgumentError, "Invalid argument dir: #{dir} must be one of #{MAPPING.keys}"
+      end
+
+      def call(context:)
+        @logic.call(context: context)
+      end
+
+      def to_s
+        @dir
       end
     end
 
@@ -22,7 +32,7 @@ module ::Rundoc::CodeCommand
       def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
         @io = io
         @contents = contents.dup if contents && !contents.empty?
-        @dir = user_args.dir
+        @dir = user_args
         @binding = RUNDOC_ERB_BINDINGS[RUNDOC_DEFAULT_ERB_BINDING]
       end
 
@@ -31,15 +41,7 @@ module ::Rundoc::CodeCommand
       end
 
       def call(env = {})
-        context = env[:context]
-        resolved_dir = case @dir
-        when :cwd
-          Dir.pwd
-        when :rundoc_root
-          context.output_dir.to_s
-        else
-          raise "ensure_later: Unknown dir value #{@dir.inspect}, expected one of: #{EnsureLaterArgs::VALID_DIRS.map(&:inspect).join(", ")}"
-        end
+        resolved_dir = @dir.call(context: env[:context])
 
         io.puts "Registering ensure_later block (dir: #{@dir} => #{resolved_dir})"
         Rundoc.add_ensure_later(dir: resolved_dir, code: @contents, binding: @binding)

--- a/lib/rundoc/code_command/rundoc/ensure_later.rb
+++ b/lib/rundoc/code_command/rundoc/ensure_later.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module ::Rundoc::CodeCommand
+  class RundocCommand
+    class EnsureLaterArgs
+      VALID_DIRS = [:cwd, :rundoc_root].freeze
+
+      attr_reader :dir
+
+      def initialize(dir:)
+        dir = dir.to_sym
+        unless VALID_DIRS.include?(dir)
+          raise ArgumentError, "Invalid dir: #{dir.inspect}, must be one of: #{VALID_DIRS.map(&:inspect).join(", ")}"
+        end
+        @dir = dir
+      end
+    end
+
+    class EnsureLaterRunner
+      attr_reader :io, :contents
+
+      def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
+        @io = io
+        @contents = contents.dup if contents && !contents.empty?
+        @dir = user_args.dir
+        @binding = RUNDOC_ERB_BINDINGS[RUNDOC_DEFAULT_ERB_BINDING]
+      end
+
+      def to_md(env = {})
+        ""
+      end
+
+      def call(env = {})
+        context = env[:context]
+        resolved_dir = case @dir
+        when :cwd
+          Dir.pwd
+        when :rundoc_root
+          context.output_dir.to_s
+        else
+          raise "ensure_later: Unknown dir value #{@dir.inspect}, expected one of: #{EnsureLaterArgs::VALID_DIRS.map(&:inspect).join(", ")}"
+        end
+
+        io.puts "Registering ensure_later block (dir: #{@dir} => #{resolved_dir})"
+        Rundoc.add_ensure_later(dir: resolved_dir, code: @contents, binding: @binding)
+        ""
+      end
+    end
+  end
+end
+
+Rundoc.register_code_command(
+  keyword: :"rundoc.ensure_later",
+  args_klass: Rundoc::CodeCommand::RundocCommand::EnsureLaterArgs,
+  runner_klass: Rundoc::CodeCommand::RundocCommand::EnsureLaterRunner,
+  always_hidden: true
+)

--- a/lib/rundoc/code_command/rundoc_command.rb
+++ b/lib/rundoc/code_command/rundoc_command.rb
@@ -26,7 +26,9 @@ module ::Rundoc
 
       def call(env = {})
         io.puts "Running: #{contents}"
-        eval(contents, @binding) # rubocop:disable Security/Eval
+        Rundoc.capture_stdout_stderr(io) do
+          eval(contents, @binding) # rubocop:disable Security/Eval
+        end
         ""
       end
     end

--- a/lib/rundoc/code_command/rundoc_command.rb
+++ b/lib/rundoc/code_command/rundoc_command.rb
@@ -37,3 +37,4 @@ Rundoc.register_code_command(keyword: :rundoc, args_klass: Rundoc::CodeCommand::
 Rundoc.register_code_command(keyword: :"rundoc.configure", args_klass: Rundoc::CodeCommand::RundocCommandArgs, runner_klass: Rundoc::CodeCommand::RundocCommandRunner)
 
 require "rundoc/code_command/rundoc/require"
+require "rundoc/code_command/rundoc/ensure_later"

--- a/lib/rundoc/peg_parser.rb
+++ b/lib/rundoc/peg_parser.rb
@@ -39,9 +39,16 @@ module Rundoc
       ).as(:number)
     }
 
+    rule(:symbol) {
+      str(":") >> (
+        match("[a-zA-Z_]") >> match("[a-zA-Z0-9_]").repeat
+      ).as(:symbol)
+    }
+
     rule(:value) {
       string |
         number |
+        symbol |
         str("true").as(true) |
         str("false").as(false) |
         str("nil").as(:nil)
@@ -175,6 +182,7 @@ module Rundoc
     rule(true => simple(:tr)) { true }
     rule(false => simple(:fa)) { false }
     rule(string: simple(:st)) { st.to_s }
+    rule(symbol: simple(:sy)) { sy.to_s.to_sym }
 
     rule(number: simple(:nb)) {
       /[eE.]/.match?(nb) ? Float(nb) : Integer(nb)

--- a/test/integration/ensure_later_test.rb
+++ b/test/integration/ensure_later_test.rb
@@ -294,4 +294,42 @@ class IntegrationEnsureLaterTest < Minitest::Test
       end
     end
   end
+
+  def test_runs_on_failure_from_subdirectory
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        dir = Pathname(dir)
+        marker = dir.join("ensure_ran.txt")
+
+        source_path = dir.join("RUNDOC.md")
+        source_path.write <<~EOF
+          ```
+          :::>> $ mkdir myapp
+          :::>> $ cd myapp
+          ```
+
+          ```
+          :::-- rundoc.ensure_later(dir: :cwd)
+          File.write("#{marker}", "cleaned")
+          ```
+
+          ```
+          :::>> $ exit 1
+          ```
+        EOF
+
+        assert_raises do
+          Rundoc::CLI.new(
+            io: StringIO.new,
+            source_path: source_path,
+            on_success_dir: dir.join(SUCCESS_DIRNAME),
+            on_failure_dir: dir.join(FAILURE_DIRNAME)
+          ).call
+        end
+
+        assert marker.exist?, "ensure_later from subdirectory should run even on failure"
+        assert_equal "cleaned", marker.read
+      end
+    end
+  end
 end

--- a/test/integration/ensure_later_test.rb
+++ b/test/integration/ensure_later_test.rb
@@ -1,0 +1,297 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class IntegrationEnsureLaterTest < Minitest::Test
+  def test_runs_on_success
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        dir = Pathname(dir)
+        marker = dir.join("ensure_ran.txt")
+
+        source_path = dir.join("RUNDOC.md")
+        source_path.write <<~EOF
+          ```
+          :::-- rundoc.ensure_later(dir: :cwd)
+          File.write("#{marker}", "yes")
+          ```
+
+          ```
+          :::>> $ echo "hello"
+          ```
+        EOF
+
+        Rundoc::CLI.new(
+          io: StringIO.new,
+          source_path: source_path,
+          on_success_dir: dir.join(SUCCESS_DIRNAME)
+        ).call
+
+        assert marker.exist?, "ensure_later block should have run on success"
+        assert_equal "yes", marker.read
+      end
+    end
+  end
+
+  def test_runs_on_failure
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        dir = Pathname(dir)
+        marker = dir.join("ensure_ran.txt")
+
+        source_path = dir.join("RUNDOC.md")
+        source_path.write <<~EOF
+          ```
+          :::-- rundoc.ensure_later(dir: :cwd)
+          File.write("#{marker}", "cleaned")
+          ```
+
+          ```
+          :::>> $ exit 1
+          ```
+        EOF
+
+        assert_raises do
+          Rundoc::CLI.new(
+            io: StringIO.new,
+            source_path: source_path,
+            on_success_dir: dir.join(SUCCESS_DIRNAME),
+            on_failure_dir: dir.join(FAILURE_DIRNAME)
+          ).call
+        end
+
+        assert marker.exist?, "ensure_later block should have run on failure"
+        assert_equal "cleaned", marker.read
+      end
+    end
+  end
+
+  def test_multiple_blocks_run_in_order
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        dir = Pathname(dir)
+        marker = dir.join("order.txt")
+
+        source_path = dir.join("RUNDOC.md")
+        source_path.write <<~EOF
+          ```
+          :::-- rundoc.ensure_later(dir: :cwd)
+          File.write("#{marker}", "first")
+          ```
+
+          ```
+          :::-- rundoc.ensure_later(dir: :cwd)
+          File.write("#{marker}", File.read("#{marker}") + ",second")
+          ```
+
+          ```
+          :::>> $ echo "hello"
+          ```
+        EOF
+
+        Rundoc::CLI.new(
+          io: StringIO.new,
+          source_path: source_path,
+          on_success_dir: dir.join(SUCCESS_DIRNAME)
+        ).call
+
+        assert_equal "first,second", marker.read
+      end
+    end
+  end
+
+  def test_one_failure_does_not_stop_others
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        dir = Pathname(dir)
+        marker = dir.join("second_ran.txt")
+
+        source_path = dir.join("RUNDOC.md")
+        source_path.write <<~EOF
+          ```
+          :::-- rundoc.ensure_later(dir: :cwd)
+          raise "intentional failure"
+          ```
+
+          ```
+          :::-- rundoc.ensure_later(dir: :cwd)
+          File.write("#{marker}", "yes")
+          ```
+
+          ```
+          :::>> $ echo "hello"
+          ```
+        EOF
+
+        error = assert_raises(RuntimeError) do
+          Rundoc::CLI.new(
+            io: StringIO.new,
+            source_path: source_path,
+            on_success_dir: dir.join(SUCCESS_DIRNAME)
+          ).call
+        end
+        assert_match(/intentional failure/, error.message)
+
+        assert marker.exist?, "second ensure_later should still run after first fails"
+      end
+    end
+  end
+
+  def test_success_plus_ensure_failure_is_overall_failure
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        dir = Pathname(dir)
+
+        source_path = dir.join("RUNDOC.md")
+        source_path.write <<~EOF
+          ```
+          :::-- rundoc.ensure_later(dir: :cwd)
+          raise "cleanup failed"
+          ```
+
+          ```
+          :::>> $ echo "hello"
+          ```
+        EOF
+
+        error = assert_raises(RuntimeError) do
+          Rundoc::CLI.new(
+            io: StringIO.new,
+            source_path: source_path,
+            on_success_dir: dir.join(SUCCESS_DIRNAME)
+          ).call
+        end
+
+        assert_match(/cleanup failed/, error.message)
+      end
+    end
+  end
+
+  def test_dir_rundoc_root
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        dir = Pathname(dir)
+        marker = dir.join("root_marker.txt")
+
+        source_path = dir.join("RUNDOC.md")
+        source_path.write <<~EOF
+          ```
+          :::>> $ mkdir subdir
+          :::>> $ cd subdir
+          ```
+
+          ```
+          :::-- rundoc.ensure_later(dir: :rundoc_root)
+          File.write("#{marker}", Dir.pwd)
+          ```
+
+          ```
+          :::>> $ echo "hello"
+          ```
+        EOF
+
+        cli = Rundoc::CLI.new(
+          io: StringIO.new,
+          source_path: source_path,
+          on_success_dir: dir.join(SUCCESS_DIRNAME)
+        )
+        output_dir = cli.execution_context.output_dir.realpath.to_s
+
+        cli.call
+
+        assert marker.exist?, "ensure_later with dir: :rundoc_root should run"
+        assert_equal output_dir, marker.read
+      end
+    end
+  end
+
+  def test_output_not_in_document
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        dir = Pathname(dir)
+
+        source_path = dir.join("RUNDOC.md")
+        source_path.write <<~EOF
+          ```
+          :::-- rundoc.ensure_later(dir: :cwd)
+          puts "THIS SHOULD NOT APPEAR"
+          ```
+
+          ```
+          :::>> $ echo "visible"
+          ```
+        EOF
+
+        Rundoc::CLI.new(
+          io: StringIO.new,
+          source_path: source_path,
+          on_success_dir: dir.join(SUCCESS_DIRNAME)
+        ).call
+
+        readme = dir.join(SUCCESS_DIRNAME).join("README.md").read
+        refute_match(/THIS SHOULD NOT APPEAR/, readme)
+        assert_match(/visible/, readme)
+      end
+    end
+  end
+
+  def test_invalid_dir_raises
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        dir = Pathname(dir)
+
+        source_path = dir.join("RUNDOC.md")
+        source_path.write <<~EOF
+          ```
+          :::-- rundoc.ensure_later(dir: :invalid)
+          puts "should not run"
+          ```
+        EOF
+
+        assert_raises(ArgumentError) do
+          Rundoc::CLI.new(
+            io: StringIO.new,
+            source_path: source_path,
+            on_success_dir: dir.join(SUCCESS_DIRNAME)
+          ).call
+        end
+      end
+    end
+  end
+
+  def test_shared_binding_with_rundoc
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        dir = Pathname(dir)
+        marker = dir.join("binding_test.txt")
+
+        source_path = dir.join("RUNDOC.md")
+        source_path.write <<~EOF
+          ```
+          :::-- rundoc
+          def my_helper
+            "from_rundoc"
+          end
+          ```
+
+          ```
+          :::-- rundoc.ensure_later(dir: :cwd)
+          File.write("#{marker}", my_helper)
+          ```
+
+          ```
+          :::>> $ echo "hello"
+          ```
+        EOF
+
+        Rundoc::CLI.new(
+          io: StringIO.new,
+          source_path: source_path,
+          on_success_dir: dir.join(SUCCESS_DIRNAME)
+        ).call
+
+        assert_equal "from_rundoc", marker.read
+      end
+    end
+  end
+end

--- a/test/rundoc/peg_parser_test.rb
+++ b/test/rundoc/peg_parser_test.rb
@@ -367,4 +367,29 @@ class PegParserTest < Minitest::Test
     assert_equal :rundoc, actual.keyword
     assert_equal "first = 1 # comment\nsecond = 2".strip, actual.contents.strip
   end
+
+  def test_symbol_value
+    input = %(:cwd)
+    parser = Rundoc::PegParser.new.symbol
+    tree = parser.parse_with_debug(input)
+    actual = @transformer.apply(tree)
+    assert_equal :cwd, actual
+  end
+
+  def test_symbol_in_named_args
+    input = %(dir: :cwd)
+    parser = Rundoc::PegParser.new.named_args
+    tree = parser.parse_with_debug(input)
+    actual = @transformer.apply(tree)
+    assert_equal({dir: :cwd}, actual)
+  end
+
+  def test_symbol_in_method_call
+    input = %(rundoc.ensure_later(dir: :cwd))
+    parser = Rundoc::PegParser.new.method_call
+    tree = parser.parse_with_debug(input)
+    actual = @transformer.apply(tree)
+    assert_equal :"rundoc.ensure_later", actual.keyword
+    assert_equal({dir: :cwd}, actual.original_args)
+  end
 end


### PR DESCRIPTION
Run a script on EVERY build (success and failure). Used to guarantee resources are cleaned up. For example:

    ```
    :::>> $ heroku create
    :::-- rundoc
    @app_name = run!("heroku info --json | jq -r '.app.name'").strip

    def app_name
      @app_name
    end
    ```

    ```ruby
    :::-- rundoc.ensure_later(dir: :cwd)
    if run!("heroku apps").include?(app_name)
      puts "Cleaning up web app #{app_name}"
      run!("heroku apps:destroy #{app_name} --confirm #{app_name}")
    else
      puts "App `#{app_name}` already cleaned, nothing to do"
    end
    ```
  
This will ensure that the app created is deleted, whether the script succeeds or not. Details in the README and in individual commits.