### PR TITLE
Enable pipefail for shell commands

### DIFF
--- a/lib/rundoc/code_command/bash.rb
+++ b/lib/rundoc/code_command/bash.rb
@@ -45,7 +45,7 @@ class Rundoc::CodeCommand::BashRunner
   end
 
   def shell(cmd, stdin = nil)
-    cmd = "(#{cmd}) 2>&1"
+    cmd = "(set -o pipefail; #{cmd}) 2>&1"
     msg = "Running: $ '#{cmd}'"
     msg << " with stdin: '#{stdin.inspect}'" if stdin && !stdin.empty?
     io.puts msg

--- a/test/rundoc/code_commands/bash_test.rb
+++ b/test/rundoc/code_commands/bash_test.rb
@@ -25,6 +25,29 @@ class BashTest < Minitest::Test
     end
   end
 
+  def test_pipefail_catches_early_failure
+    command = "false | true"
+    bash = Rundoc::CodeCommand::BashRunner.new(
+      render_command: false,
+      render_result: false,
+      io: StringIO.new,
+      user_args: Rundoc::CodeCommand::BashArgs.new(command)
+    )
+    error = assert_raises(RuntimeError) { bash.call }
+    assert_match(/exited with non zero status/, error.message)
+  end
+
+  def test_pipefail_allows_fail_ok
+    command = "false | true"
+    bash = Rundoc::CodeCommand::BashRunnerFailOk.new(
+      render_command: false,
+      render_result: false,
+      io: StringIO.new,
+      user_args: Rundoc::CodeCommand::BashArgs.new(command)
+    )
+    bash.call
+  end
+
   def test_stdin
     command = "tail -n 2"
     bash = Rundoc::CodeCommand::BashRunner.new(


### PR DESCRIPTION
## Summary

- Prepend `set -o pipefail` to the subshell wrapper in `BashRunner#shell` so that pipeline failures are properly detected.
- Without this, a command like `git push heroku main | tee deploy.log` would silently swallow a push failure because only the last pipeline command's exit status (`tee`, exit 0) was reported.
- Add tests verifying that `BashRunner` raises on `false | true` and that `BashRunnerFailOk` still allows it.

## Test plan

- [x] All 113 existing tests pass with 0 failures
- [x] New `test_pipefail_catches_early_failure` confirms `false | true` raises a RuntimeError
- [x] New `test_pipefail_allows_fail_ok` confirms `BashRunnerFailOk` does not raise on the same pipeline