### PR TITLE
Fix ensure_later log to show dir mode instead of object inspect

### DIFF
--- a/lib/rundoc/code_command/rundoc/ensure_later.rb
+++ b/lib/rundoc/code_command/rundoc/ensure_later.rb
@@ -22,7 +22,7 @@ module ::Rundoc::CodeCommand
       end
 
       def to_s
-        @dir
+        @dir.to_s
       end
     end
 

--- a/test/integration/ensure_later_test.rb
+++ b/test/integration/ensure_later_test.rb
@@ -332,4 +332,34 @@ class IntegrationEnsureLaterTest < Minitest::Test
       end
     end
   end
+
+  def test_log_output_shows_dir_mode_name
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        dir = Pathname(dir)
+
+        source_path = dir.join("RUNDOC.md")
+        source_path.write <<~EOF
+          ```
+          :::-- rundoc.ensure_later(dir: :cwd)
+          puts "hello"
+          ```
+
+          ```
+          :::>> $ echo "hello"
+          ```
+        EOF
+
+        io = StringIO.new
+        Rundoc::CLI.new(
+          io: io,
+          source_path: source_path,
+          on_success_dir: dir.join(SUCCESS_DIRNAME)
+        ).call
+
+        output = io.string
+        assert_includes output, "Registering ensure_later block (dir: cwd => /"
+      end
+    end
+  end
 end


### PR DESCRIPTION
EnsureLaterArgs#to_s returned a Symbol, but Ruby 3.x falls back to
Object#to_s when to_s doesn't return a String. This caused the
registration log to show the raw object representation instead of
the mode name (e.g., "cwd" or "rundoc_root").

Fixes #126