### PR TITLE
Add match: / match_first: kwargs to file.append and new file.before command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Added: `match:` and `match_first:` kwargs to `file.append` for locating the insertion point by content instead of line number. `match:` raises if the target is not unique; `match_first:` uses the first occurrence.
+- Added: `file.before` command with the same `match:` / `match_first:` kwargs. Inserts content before the matched line.
 - Changed: Shell commands now run under `bash -eo pipefail` instead of `/bin/sh`. This surfaces failures in pipelines and compound commands that were previously swallowed. See the README for details on SIGPIPE interactions.
 
 ## 6.0.0

--- a/lib/rundoc/code_command/file_command/append.rb
+++ b/lib/rundoc/code_command/file_command/append.rb
@@ -61,7 +61,7 @@ class Rundoc::CodeCommand::FileCommand
       end
 
       env[:before] << if match_string
-        "In file `#{filename}`, on line matching `#{match_string}`, add:"
+        "In file `#{filename}`, after `#{match_string}`, add:"
       elsif @line_number
         "In file `#{filename}`, on line #{@line_number} add:"
       else
@@ -71,71 +71,32 @@ class Rundoc::CodeCommand::FileCommand
       nil
     end
 
-    def last_char_of(string)
-      string[-1, 1]
-    end
-
-    def ends_in_newline?(string)
-      last_char_of(string) == "\n"
-    end
-
     def concat_with_newline(str1, str2)
       result = +""
       result << str1
-      result << "\n" unless ends_in_newline?(result)
+      result << "\n" unless str1.end_with?("\n")
       result << str2
-      result << "\n" unless ends_in_newline?(result)
+      result << "\n" unless str2.end_with?("\n")
       result
-    end
-
-    def insert_contents_into_at_line(doc)
-      lines = doc.lines
-      raise "Expected #{filename} to have at least #{@line_number} but only has #{lines.count}" if lines.count < @line_number
-      result = []
-      lines.each_with_index do |line, index|
-        line_number = index.next
-        if line_number == @line_number
-          result << contents
-          result << "\n" unless ends_in_newline?(contents)
-        end
-        result << line
-      end
-      result.flatten.join("")
-    end
-
-    def insert_contents_before_match(doc)
-      lines = doc.lines
-      matching_indices = lines.each_index.select { |i| lines[i].include?(match_string) }
-
-      if matching_indices.empty?
-        raise "Could not find match #{match_string.inspect} in #{filename}"
-      end
-
-      if @match && matching_indices.length != 1
-        raise "Expected 1 match for #{match_string.inspect} in #{filename} but found #{matching_indices.length}. Use match_first: if multiple matches are expected."
-      end
-
-      target = matching_indices.first
-      io.puts "Inserting at line #{target + 1} before #{match_string.inspect} in '#{filename}' with: #{contents.inspect}"
-      result = []
-      lines.each_with_index do |line, index|
-        if index == target
-          result << contents
-          result << "\n" unless ends_in_newline?(contents)
-        end
-        result << line
-      end
-      result.join("")
     end
 
     def call(env = {})
       mkdir_p
       doc = File.read(filename)
       if match_string
-        doc = insert_contents_before_match(doc)
+        line = Rundoc::CodeCommand::FileUtil.resolve_match_line(
+          doc: doc, match_str: match_string, filename: filename, unique: !!@match
+        )
+        line += 1
+        io.puts "Inserting at line #{line} after #{match_string.inspect} in '#{filename}' with: #{contents.inspect}"
+        doc = Rundoc::CodeCommand::FileUtil.insert_contents_at_line(
+          doc: doc, line_number: line, contents: contents, filename: filename
+        )
       elsif @line_number
         io.puts "Writing to: '#{filename}' line #{@line_number} with: #{contents.inspect}"
-        doc = insert_contents_into_at_line(doc)
+        doc = Rundoc::CodeCommand::FileUtil.insert_contents_at_line(
+          doc: doc, line_number: @line_number, contents: contents, filename: filename
+        )
       else
         io.puts "Appending to file: '#{filename}' with: #{contents.inspect}"
         doc = concat_with_newline(doc, contents)

--- a/lib/rundoc/code_command/file_command/append.rb
+++ b/lib/rundoc/code_command/file_command/append.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class Rundoc::CodeCommand::FileCommand
-  class AppendArgs
-    attr_reader :filename, :match, :match_first
+  class InsertArgs
+    attr_reader :filename, :match, :match_first, :line_number
 
     def initialize(filename, match: nil, match_first: nil)
-      @filename = filename
+      @filename, line = filename.split("#")
+      @line_number = Integer(line) if line
       @match = match
       @match_first = match_first
 
@@ -16,6 +17,14 @@ class Rundoc::CodeCommand::FileCommand
       if (@match || @match_first)&.empty?
         raise "match value cannot be empty"
       end
+
+      if match_string && @line_number
+        raise "Cannot use both match: and #line_number"
+      end
+    end
+
+    def match_string
+      @match || @match_first
     end
   end
 
@@ -27,18 +36,10 @@ class Rundoc::CodeCommand::FileCommand
     attr_reader :io, :contents
 
     def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
+      @filename = user_args.filename
       @match = user_args.match
       @match_first = user_args.match_first
-
-      @filename, line = user_args.filename.split("#")
-      @line_number = if line
-        Integer(line)
-      end
-
-      if match_string && @line_number
-        raise "Cannot use both match: and #line_number"
-      end
-
+      @line_number = user_args.line_number
       @io = io
       @render_command = render_command
       @contents = contents.dup if contents && !contents.empty?
@@ -146,4 +147,4 @@ class Rundoc::CodeCommand::FileCommand
   end
 end
 
-Rundoc.register_code_command(keyword: :"file.append", args_klass: Rundoc::CodeCommand::FileCommand::AppendArgs, runner_klass: Rundoc::CodeCommand::FileCommand::AppendRunner)
+Rundoc.register_code_command(keyword: :"file.append", args_klass: Rundoc::CodeCommand::FileCommand::InsertArgs, runner_klass: Rundoc::CodeCommand::FileCommand::AppendRunner)

--- a/lib/rundoc/code_command/file_command/append.rb
+++ b/lib/rundoc/code_command/file_command/append.rb
@@ -2,10 +2,20 @@
 
 class Rundoc::CodeCommand::FileCommand
   class AppendArgs
-    attr_reader :filename
+    attr_reader :filename, :match, :match_first
 
-    def initialize(filename)
+    def initialize(filename, match: nil, match_first: nil)
       @filename = filename
+      @match = match
+      @match_first = match_first
+
+      if @match && @match_first
+        raise "Cannot use both match: and match_first:"
+      end
+
+      if (@match || @match_first)&.empty?
+        raise "match value cannot be empty"
+      end
     end
   end
 
@@ -17,13 +27,25 @@ class Rundoc::CodeCommand::FileCommand
     attr_reader :io, :contents
 
     def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
+      @match = user_args.match
+      @match_first = user_args.match_first
+
       @filename, line = user_args.filename.split("#")
       @line_number = if line
         Integer(line)
       end
+
+      if match_string && @line_number
+        raise "Cannot use both match: and #line_number"
+      end
+
       @io = io
       @render_command = render_command
       @contents = contents.dup if contents && !contents.empty?
+    end
+
+    def match_string
+      @match || @match_first
     end
 
     def render_command?
@@ -37,7 +59,9 @@ class Rundoc::CodeCommand::FileCommand
         raise "Must call append in its own code section"
       end
 
-      env[:before] << if @line_number
+      env[:before] << if match_string
+        "In file `#{filename}`, on line matching `#{match_string}`, add:"
+      elsif @line_number
         "In file `#{filename}`, on line #{@line_number} add:"
       else
         "At the end of `#{filename}` add:"
@@ -78,10 +102,37 @@ class Rundoc::CodeCommand::FileCommand
       result.flatten.join("")
     end
 
+    def insert_contents_before_match(doc)
+      lines = doc.lines
+      matching_indices = lines.each_index.select { |i| lines[i].include?(match_string) }
+
+      if matching_indices.empty?
+        raise "Could not find match #{match_string.inspect} in #{filename}"
+      end
+
+      if @match && matching_indices.length != 1
+        raise "Expected 1 match for #{match_string.inspect} in #{filename} but found #{matching_indices.length}. Use match_first: if multiple matches are expected."
+      end
+
+      target = matching_indices.first
+      io.puts "Inserting at line #{target + 1} before #{match_string.inspect} in '#{filename}' with: #{contents.inspect}"
+      result = []
+      lines.each_with_index do |line, index|
+        if index == target
+          result << contents
+          result << "\n" unless ends_in_newline?(contents)
+        end
+        result << line
+      end
+      result.join("")
+    end
+
     def call(env = {})
       mkdir_p
       doc = File.read(filename)
-      if @line_number
+      if match_string
+        doc = insert_contents_before_match(doc)
+      elsif @line_number
         io.puts "Writing to: '#{filename}' line #{@line_number} with: #{contents.inspect}"
         doc = insert_contents_into_at_line(doc)
       else

--- a/lib/rundoc/code_command/file_command/before.rb
+++ b/lib/rundoc/code_command/file_command/before.rb
@@ -1,28 +1,6 @@
 # frozen_string_literal: true
 
 class Rundoc::CodeCommand::FileCommand
-  class BeforeArgs
-    attr_reader :filename, :match, :match_first
-
-    def initialize(filename, match: nil, match_first: nil)
-      @filename = filename
-      @match = match
-      @match_first = match_first
-
-      if @match && @match_first
-        raise "Cannot use both match: and match_first:"
-      end
-
-      if @match.nil? && @match_first.nil?
-        raise "file.before requires match: or match_first:"
-      end
-
-      if (@match || @match_first)&.empty?
-        raise "match value cannot be empty"
-      end
-    end
-  end
-
   class BeforeRunner
     NEWLINE = Rundoc::CodeCommand::WriteRunner::NEWLINE
 
@@ -34,17 +12,18 @@ class Rundoc::CodeCommand::FileCommand
       @filename = user_args.filename
       @match = user_args.match
       @match_first = user_args.match_first
+      @line_number = user_args.line_number
       @io = io
       @render_command = render_command
       @contents = contents.dup if contents && !contents.empty?
     end
 
-    def render_command?
-      @render_command
-    end
-
     def match_string
       @match || @match_first
+    end
+
+    def render_command?
+      @render_command
     end
 
     def to_md(env)
@@ -54,7 +33,13 @@ class Rundoc::CodeCommand::FileCommand
         raise "Must call file.before in its own code section"
       end
 
-      env[:before] << "In file `#{filename}`, before `#{match_string}`, add:"
+      env[:before] << if match_string
+        "In file `#{filename}`, before `#{match_string}`, add:"
+      elsif @line_number
+        "In file `#{filename}`, before line #{@line_number}, add:"
+      else
+        "At the beginning of `#{filename}` add:"
+      end
       env[:before] << NEWLINE
       nil
     end
@@ -91,11 +76,24 @@ class Rundoc::CodeCommand::FileCommand
     def call(env = {})
       mkdir_p
       doc = File.read(filename)
-      doc = insert_contents_before_match(doc)
+      if match_string
+        doc = insert_contents_before_match(doc)
+      elsif @line_number
+        io.puts "Writing to: '#{filename}' before line #{@line_number} with: #{contents.inspect}"
+        doc = Rundoc::CodeCommand::FileUtil.insert_contents_at_line(
+          doc: doc, line_number: @line_number, contents: contents, filename: filename
+        )
+      else
+        io.puts "Prepending to file: '#{filename}' with: #{contents.inspect}"
+        doc = Rundoc::CodeCommand::FileUtil.insert_contents_at_line(
+          doc: doc, line_number: 1, contents: contents, filename: filename
+        )
+      end
+
       File.write(filename, doc)
       contents
     end
   end
 end
 
-Rundoc.register_code_command(keyword: :"file.before", args_klass: Rundoc::CodeCommand::FileCommand::BeforeArgs, runner_klass: Rundoc::CodeCommand::FileCommand::BeforeRunner)
+Rundoc.register_code_command(keyword: :"file.before", args_klass: Rundoc::CodeCommand::FileCommand::InsertArgs, runner_klass: Rundoc::CodeCommand::FileCommand::BeforeRunner)

--- a/lib/rundoc/code_command/file_command/before.rb
+++ b/lib/rundoc/code_command/file_command/before.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+class Rundoc::CodeCommand::FileCommand
+  class BeforeArgs
+    attr_reader :filename, :match, :match_first
+
+    def initialize(filename, match: nil, match_first: nil)
+      @filename = filename
+      @match = match
+      @match_first = match_first
+
+      if @match && @match_first
+        raise "Cannot use both match: and match_first:"
+      end
+
+      if @match.nil? && @match_first.nil?
+        raise "file.before requires match: or match_first:"
+      end
+
+      if (@match || @match_first)&.empty?
+        raise "match value cannot be empty"
+      end
+    end
+  end
+
+  class BeforeRunner
+    NEWLINE = Rundoc::CodeCommand::WriteRunner::NEWLINE
+
+    include Rundoc::CodeCommand::FileUtil
+
+    attr_reader :io, :contents
+
+    def initialize(user_args:, render_command:, render_result:, io:, contents: nil)
+      @filename = user_args.filename
+      @match = user_args.match
+      @match_first = user_args.match_first
+      @io = io
+      @render_command = render_command
+      @contents = contents.dup if contents && !contents.empty?
+    end
+
+    def render_command?
+      @render_command
+    end
+
+    def match_string
+      @match || @match_first
+    end
+
+    def to_md(env)
+      return unless render_command?
+
+      if env[:commands].any? { |c| c[:visibility].not_hidden? }
+        raise "Must call file.before in its own code section"
+      end
+
+      env[:before] << "In file `#{filename}`, before `#{match_string}`, add:"
+      env[:before] << NEWLINE
+      nil
+    end
+
+    def ends_in_newline?(string)
+      string[-1, 1] == "\n"
+    end
+
+    def insert_contents_before_match(doc)
+      lines = doc.lines
+      matching_indices = lines.each_index.select { |i| lines[i].include?(match_string) }
+
+      if matching_indices.empty?
+        raise "Could not find match #{match_string.inspect} in #{filename}"
+      end
+
+      if @match && matching_indices.length != 1
+        raise "Expected 1 match for #{match_string.inspect} in #{filename} but found #{matching_indices.length}. Use match_first: if multiple matches are expected."
+      end
+
+      target = matching_indices.first
+      io.puts "Inserting at line #{target + 1} before #{match_string.inspect} in '#{filename}' with: #{contents.inspect}"
+      result = []
+      lines.each_with_index do |line, index|
+        if index == target
+          result << contents
+          result << "\n" unless ends_in_newline?(contents)
+        end
+        result << line
+      end
+      result.join("")
+    end
+
+    def call(env = {})
+      mkdir_p
+      doc = File.read(filename)
+      doc = insert_contents_before_match(doc)
+      File.write(filename, doc)
+      contents
+    end
+  end
+end
+
+Rundoc.register_code_command(keyword: :"file.before", args_klass: Rundoc::CodeCommand::FileCommand::BeforeArgs, runner_klass: Rundoc::CodeCommand::FileCommand::BeforeRunner)

--- a/lib/rundoc/code_command/file_command/before.rb
+++ b/lib/rundoc/code_command/file_command/before.rb
@@ -44,52 +44,24 @@ class Rundoc::CodeCommand::FileCommand
       nil
     end
 
-    def ends_in_newline?(string)
-      string[-1, 1] == "\n"
-    end
-
-    def insert_contents_before_match(doc)
-      lines = doc.lines
-      matching_indices = lines.each_index.select { |i| lines[i].include?(match_string) }
-
-      if matching_indices.empty?
-        raise "Could not find match #{match_string.inspect} in #{filename}"
-      end
-
-      if @match && matching_indices.length != 1
-        raise "Expected 1 match for #{match_string.inspect} in #{filename} but found #{matching_indices.length}. Use match_first: if multiple matches are expected."
-      end
-
-      target = matching_indices.first
-      io.puts "Inserting at line #{target + 1} before #{match_string.inspect} in '#{filename}' with: #{contents.inspect}"
-      result = []
-      lines.each_with_index do |line, index|
-        if index == target
-          result << contents
-          result << "\n" unless ends_in_newline?(contents)
-        end
-        result << line
-      end
-      result.join("")
-    end
-
     def call(env = {})
       mkdir_p
       doc = File.read(filename)
       if match_string
-        doc = insert_contents_before_match(doc)
+        line = Rundoc::CodeCommand::FileUtil.resolve_match_line(
+          doc: doc, match_str: match_string, filename: filename, unique: !!@match
+        )
+        io.puts "Inserting at line #{line} before #{match_string.inspect} in '#{filename}' with: #{contents.inspect}"
       elsif @line_number
-        io.puts "Writing to: '#{filename}' before line #{@line_number} with: #{contents.inspect}"
-        doc = Rundoc::CodeCommand::FileUtil.insert_contents_at_line(
-          doc: doc, line_number: @line_number, contents: contents, filename: filename
-        )
+        line = @line_number
+        io.puts "Writing to: '#{filename}' before line #{line} with: #{contents.inspect}"
       else
+        line = 1
         io.puts "Prepending to file: '#{filename}' with: #{contents.inspect}"
-        doc = Rundoc::CodeCommand::FileUtil.insert_contents_at_line(
-          doc: doc, line_number: 1, contents: contents, filename: filename
-        )
       end
-
+      doc = Rundoc::CodeCommand::FileUtil.insert_contents_at_line(
+        doc: doc, line_number: line, contents: contents, filename: filename
+      )
       File.write(filename, doc)
       contents
     end

--- a/lib/rundoc/code_command/write.rb
+++ b/lib/rundoc/code_command/write.rb
@@ -75,4 +75,5 @@ Rundoc.register_code_command(keyword: :write, args_klass: Rundoc::CodeCommand::W
 Rundoc.register_code_command(keyword: :"file.write", args_klass: Rundoc::CodeCommand::WriteArgs, runner_klass: Rundoc::CodeCommand::WriteRunner)
 
 require "rundoc/code_command/file_command/append"
+require "rundoc/code_command/file_command/before"
 require "rundoc/code_command/file_command/remove"

--- a/lib/rundoc/code_command/write.rb
+++ b/lib/rundoc/code_command/write.rb
@@ -15,6 +15,44 @@ module Rundoc
         dir = File.expand_path("../", filename)
         FileUtils.mkdir_p(dir)
       end
+
+      def self.resolve_match_line(doc:, match_str:, filename:, unique:)
+        lines = doc.lines
+        matching_indices = lines.each_index.select { |i| lines[i].include?(match_str) }
+
+        if matching_indices.empty?
+          raise "Could not find match #{match_str.inspect} in #{filename}"
+        end
+
+        if unique && matching_indices.length != 1
+          raise "Expected 1 match for #{match_str.inspect} in #{filename} but found #{matching_indices.length}. Use match_first: if multiple matches are expected."
+        end
+
+        matching_indices.first + 1
+      end
+
+      def self.insert_contents_at_line(doc:, line_number:, contents:, filename:)
+        lines = doc.lines
+        if line_number > lines.count + 1
+          raise "Expected #{filename} to have at least #{line_number - 1} lines but only has #{lines.count}"
+        end
+
+        result = []
+        lines.each_with_index do |line, index|
+          if index.next == line_number
+            result << contents
+            result << "\n" unless contents.end_with?("\n")
+          end
+          result << line
+        end
+
+        if line_number == lines.count + 1
+          result << contents
+          result << "\n" unless contents.end_with?("\n")
+        end
+
+        result.join("")
+      end
     end
 
     class WriteArgs

--- a/test/rundoc/code_commands/append_file_test.rb
+++ b/test/rundoc/code_commands/append_file_test.rb
@@ -11,7 +11,7 @@ class AppendFileTest < Minitest::Test
           render_command: false,
           render_result: false,
           io: StringIO.new,
-          user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file),
+          user_args: Rundoc::CodeCommand::FileCommand::InsertArgs.new(file),
           contents: "bar"
         )
         cc.call
@@ -25,7 +25,7 @@ class AppendFileTest < Minitest::Test
           render_command: false,
           render_result: false,
           io: StringIO.new,
-          user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file),
+          user_args: Rundoc::CodeCommand::FileCommand::InsertArgs.new(file),
           contents: "baz"
         )
         cc.call
@@ -53,7 +53,7 @@ class AppendFileTest < Minitest::Test
           render_command: false,
           render_result: false,
           io: StringIO.new,
-          user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("#{file}##{line}"),
+          user_args: Rundoc::CodeCommand::FileCommand::InsertArgs.new("#{file}##{line}"),
           contents: "gem 'pg'"
         )
         cc.call
@@ -73,7 +73,7 @@ class AppendFileTest < Minitest::Test
           render_command: false,
           render_result: false,
           io: StringIO.new,
-          user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("file-*.txt"),
+          user_args: Rundoc::CodeCommand::FileCommand::InsertArgs.new("file-*.txt"),
           contents: "some text"
         )
         cc.call
@@ -93,7 +93,7 @@ class AppendFileTest < Minitest::Test
             render_command: false,
             render_result: false,
             io: StringIO.new,
-            user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("file-*.txt"),
+            user_args: Rundoc::CodeCommand::FileCommand::InsertArgs.new("file-*.txt"),
             contents: "some text"
           )
           cc.call
@@ -112,7 +112,7 @@ class AppendFileTest < Minitest::Test
           render_command: false,
           render_result: false,
           io: StringIO.new,
-          user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file, match: "gem 'rails'"),
+          user_args: Rundoc::CodeCommand::FileCommand::InsertArgs.new(file, match: "gem 'rails'"),
           contents: "gem 'pg'"
         )
         cc.call
@@ -133,7 +133,7 @@ class AppendFileTest < Minitest::Test
           render_command: false,
           render_result: false,
           io: StringIO.new,
-          user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file, match_first: "import"),
+          user_args: Rundoc::CodeCommand::FileCommand::InsertArgs.new(file, match_first: "import"),
           contents: "import json"
         )
         cc.call
@@ -155,7 +155,7 @@ class AppendFileTest < Minitest::Test
             render_command: false,
             render_result: false,
             io: StringIO.new,
-            user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file, match: "gem 'rails'"),
+            user_args: Rundoc::CodeCommand::FileCommand::InsertArgs.new(file, match: "gem 'rails'"),
             contents: "gem 'pg'"
           )
           cc.call
@@ -176,7 +176,7 @@ class AppendFileTest < Minitest::Test
             render_command: false,
             render_result: false,
             io: StringIO.new,
-            user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("#{file}#2", match: "line two"),
+            user_args: Rundoc::CodeCommand::FileCommand::InsertArgs.new("#{file}#2", match: "line two"),
             contents: "inserted"
           )
         end

--- a/test/rundoc/code_commands/append_file_test.rb
+++ b/test/rundoc/code_commands/append_file_test.rb
@@ -101,4 +101,87 @@ class AppendFileTest < Minitest::Test
       end
     end
   end
+
+  def test_appends_to_a_file_at_match
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        file = "Gemfile"
+        File.write(file, "source 'https://rubygems.org'\ngem 'rails', '4.0.0'\n")
+
+        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(
+          render_command: false,
+          render_result: false,
+          io: StringIO.new,
+          user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file, match: "gem 'rails'"),
+          contents: "gem 'pg'"
+        )
+        cc.call
+
+        expected = "source 'https://rubygems.org'\ngem 'pg'\ngem 'rails', '4.0.0'\n"
+        assert_equal expected, File.read(file)
+      end
+    end
+  end
+
+  def test_appends_to_a_file_at_match_first
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        file = "app.py"
+        File.write(file, "import os\nimport sys\nprint('hello')\n")
+
+        cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(
+          render_command: false,
+          render_result: false,
+          io: StringIO.new,
+          user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file, match_first: "import"),
+          contents: "import json"
+        )
+        cc.call
+
+        expected = "import json\nimport os\nimport sys\nprint('hello')\n"
+        assert_equal expected, File.read(file)
+      end
+    end
+  end
+
+  def test_appends_to_a_file_at_match_raises_when_not_found
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        file = "Gemfile"
+        File.write(file, "source 'https://rubygems.org'\n")
+
+        error = assert_raises(RuntimeError) do
+          cc = Rundoc::CodeCommand::FileCommand::AppendRunner.new(
+            render_command: false,
+            render_result: false,
+            io: StringIO.new,
+            user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new(file, match: "gem 'rails'"),
+            contents: "gem 'pg'"
+          )
+          cc.call
+        end
+        assert_match(/Could not find match/, error.message)
+      end
+    end
+  end
+
+  def test_appends_raises_when_match_and_line_number_both_used
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        file = "foo.rb"
+        File.write(file, "line one\nline two\n")
+
+        error = assert_raises(RuntimeError) do
+          Rundoc::CodeCommand::FileCommand::AppendRunner.new(
+            render_command: false,
+            render_result: false,
+            io: StringIO.new,
+            user_args: Rundoc::CodeCommand::FileCommand::AppendArgs.new("#{file}#2", match: "line two"),
+            contents: "inserted"
+          )
+        end
+        assert_match(/Cannot use both match: and #line_number/, error.message)
+      end
+    end
+  end
 end

--- a/test/rundoc/code_commands/append_file_test.rb
+++ b/test/rundoc/code_commands/append_file_test.rb
@@ -117,7 +117,7 @@ class AppendFileTest < Minitest::Test
         )
         cc.call
 
-        expected = "source 'https://rubygems.org'\ngem 'pg'\ngem 'rails', '4.0.0'\n"
+        expected = "source 'https://rubygems.org'\ngem 'rails', '4.0.0'\ngem 'pg'\n"
         assert_equal expected, File.read(file)
       end
     end
@@ -138,7 +138,7 @@ class AppendFileTest < Minitest::Test
         )
         cc.call
 
-        expected = "import json\nimport os\nimport sys\nprint('hello')\n"
+        expected = "import os\nimport json\nimport sys\nprint('hello')\n"
         assert_equal expected, File.read(file)
       end
     end

--- a/test/rundoc/code_commands/before_file_test.rb
+++ b/test/rundoc/code_commands/before_file_test.rb
@@ -15,7 +15,7 @@ class BeforeFileTest < Minitest::Test
           render_command: false,
           render_result: false,
           io: StringIO.new,
-          user_args: Rundoc::CodeCommand::FileCommand::BeforeArgs.new(file, match: "// Cleanup after server close"),
+          user_args: Rundoc::CodeCommand::FileCommand::InsertArgs.new(file, match: "// Cleanup after server close"),
           contents: "pool.end()"
         )
         cc.call
@@ -42,7 +42,7 @@ class BeforeFileTest < Minitest::Test
             render_command: false,
             render_result: false,
             io: StringIO.new,
-            user_args: Rundoc::CodeCommand::FileCommand::BeforeArgs.new(file, match: "marker"),
+            user_args: Rundoc::CodeCommand::FileCommand::InsertArgs.new(file, match: "marker"),
             contents: "inserted"
           )
           cc.call
@@ -63,7 +63,7 @@ class BeforeFileTest < Minitest::Test
           render_command: false,
           render_result: false,
           io: StringIO.new,
-          user_args: Rundoc::CodeCommand::FileCommand::BeforeArgs.new(file, match_first: "import"),
+          user_args: Rundoc::CodeCommand::FileCommand::InsertArgs.new(file, match_first: "import"),
           contents: "import json"
         )
         cc.call
@@ -85,7 +85,7 @@ class BeforeFileTest < Minitest::Test
             render_command: false,
             render_result: false,
             io: StringIO.new,
-            user_args: Rundoc::CodeCommand::FileCommand::BeforeArgs.new(file, match: "not here"),
+            user_args: Rundoc::CodeCommand::FileCommand::InsertArgs.new(file, match: "not here"),
             contents: "inserted"
           )
           cc.call
@@ -97,23 +97,37 @@ class BeforeFileTest < Minitest::Test
 
   def test_before_raises_when_match_value_is_empty_string
     error = assert_raises(RuntimeError) do
-      Rundoc::CodeCommand::FileCommand::BeforeArgs.new("file.txt", match: "")
+      Rundoc::CodeCommand::FileCommand::InsertArgs.new("file.txt", match: "")
     end
     assert_match(/match value cannot be empty/, error.message)
   end
 
   def test_before_raises_when_both_match_and_match_first
     error = assert_raises(RuntimeError) do
-      Rundoc::CodeCommand::FileCommand::BeforeArgs.new("file.txt", match: "a", match_first: "b")
+      Rundoc::CodeCommand::FileCommand::InsertArgs.new("file.txt", match: "a", match_first: "b")
     end
     assert_match(/Cannot use both match: and match_first:/, error.message)
   end
 
-  def test_before_raises_when_neither_match_nor_match_first
-    error = assert_raises(RuntimeError) do
-      Rundoc::CodeCommand::FileCommand::BeforeArgs.new("file.txt")
+  def test_before_prepends_to_head_when_no_match_or_line
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        file = "app.txt"
+        File.write(file, "line one\nline two\n")
+
+        cc = Rundoc::CodeCommand::FileCommand::BeforeRunner.new(
+          render_command: false,
+          render_result: false,
+          io: StringIO.new,
+          user_args: Rundoc::CodeCommand::FileCommand::InsertArgs.new(file),
+          contents: "line zero"
+        )
+        cc.call
+
+        expected = "line zero\nline one\nline two\n"
+        assert_equal expected, File.read(file)
+      end
     end
-    assert_match(/file\.before requires match: or match_first:/, error.message)
   end
 
   def test_before_to_md_output
@@ -126,7 +140,7 @@ class BeforeFileTest < Minitest::Test
           render_command: true,
           render_result: false,
           io: StringIO.new,
-          user_args: Rundoc::CodeCommand::FileCommand::BeforeArgs.new(file, match: "marker"),
+          user_args: Rundoc::CodeCommand::FileCommand::InsertArgs.new(file, match: "marker"),
           contents: "inserted"
         )
 

--- a/test/rundoc/code_commands/before_file_test.rb
+++ b/test/rundoc/code_commands/before_file_test.rb
@@ -1,0 +1,143 @@
+require "test_helper"
+
+class BeforeFileTest < Minitest::Test
+  def test_before_match_inserts_content_before_matched_line
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        file = "app.js"
+        File.write(file, <<~CONTENTS)
+          server.close()
+          // Cleanup after server close
+          })
+        CONTENTS
+
+        cc = Rundoc::CodeCommand::FileCommand::BeforeRunner.new(
+          render_command: false,
+          render_result: false,
+          io: StringIO.new,
+          user_args: Rundoc::CodeCommand::FileCommand::BeforeArgs.new(file, match: "// Cleanup after server close"),
+          contents: "pool.end()"
+        )
+        cc.call
+
+        expected = <<~EXPECTED
+          server.close()
+          pool.end()
+          // Cleanup after server close
+          })
+        EXPECTED
+        assert_equal expected, File.read(file)
+      end
+    end
+  end
+
+  def test_before_match_raises_when_multiple_matches
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        file = "app.txt"
+        File.write(file, "line one\nmarker\nline three\nmarker\n")
+
+        error = assert_raises(RuntimeError) do
+          cc = Rundoc::CodeCommand::FileCommand::BeforeRunner.new(
+            render_command: false,
+            render_result: false,
+            io: StringIO.new,
+            user_args: Rundoc::CodeCommand::FileCommand::BeforeArgs.new(file, match: "marker"),
+            contents: "inserted"
+          )
+          cc.call
+        end
+        assert_match(/Expected 1 match/, error.message)
+        assert_match(/but found 2/, error.message)
+      end
+    end
+  end
+
+  def test_before_match_first_inserts_before_first_of_multiple
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        file = "app.py"
+        File.write(file, "import os\nimport sys\nprint('hello')\n")
+
+        cc = Rundoc::CodeCommand::FileCommand::BeforeRunner.new(
+          render_command: false,
+          render_result: false,
+          io: StringIO.new,
+          user_args: Rundoc::CodeCommand::FileCommand::BeforeArgs.new(file, match_first: "import"),
+          contents: "import json"
+        )
+        cc.call
+
+        expected = "import json\nimport os\nimport sys\nprint('hello')\n"
+        assert_equal expected, File.read(file)
+      end
+    end
+  end
+
+  def test_before_raises_when_match_not_found
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        file = "app.txt"
+        File.write(file, "line one\nline two\n")
+
+        error = assert_raises(RuntimeError) do
+          cc = Rundoc::CodeCommand::FileCommand::BeforeRunner.new(
+            render_command: false,
+            render_result: false,
+            io: StringIO.new,
+            user_args: Rundoc::CodeCommand::FileCommand::BeforeArgs.new(file, match: "not here"),
+            contents: "inserted"
+          )
+          cc.call
+        end
+        assert_match(/Could not find match/, error.message)
+      end
+    end
+  end
+
+  def test_before_raises_when_match_value_is_empty_string
+    error = assert_raises(RuntimeError) do
+      Rundoc::CodeCommand::FileCommand::BeforeArgs.new("file.txt", match: "")
+    end
+    assert_match(/match value cannot be empty/, error.message)
+  end
+
+  def test_before_raises_when_both_match_and_match_first
+    error = assert_raises(RuntimeError) do
+      Rundoc::CodeCommand::FileCommand::BeforeArgs.new("file.txt", match: "a", match_first: "b")
+    end
+    assert_match(/Cannot use both match: and match_first:/, error.message)
+  end
+
+  def test_before_raises_when_neither_match_nor_match_first
+    error = assert_raises(RuntimeError) do
+      Rundoc::CodeCommand::FileCommand::BeforeArgs.new("file.txt")
+    end
+    assert_match(/file\.before requires match: or match_first:/, error.message)
+  end
+
+  def test_before_to_md_output
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        file = "app.txt"
+        File.write(file, "marker\n")
+
+        cc = Rundoc::CodeCommand::FileCommand::BeforeRunner.new(
+          render_command: true,
+          render_result: false,
+          io: StringIO.new,
+          user_args: Rundoc::CodeCommand::FileCommand::BeforeArgs.new(file, match: "marker"),
+          contents: "inserted"
+        )
+
+        env = {}
+        env[:commands] = []
+        env[:before] = []
+        env[:fence_start] = "```"
+        cc.to_md(env)
+
+        assert_equal "In file `app.txt`, before `marker`, add:", env[:before].first
+      end
+    end
+  end
+end


### PR DESCRIPTION
Appending content at a specific line number (`file.append Gemfile#5`) breaks
when the target file changes unexpectedly -- the line number drifts and content
lands in the wrong place. This happened in practice with the Node.js Getting
Started tutorial (see heroku/nodejs-getting-started#403).

This adds `match:` and `match_first:` kwargs so the insertion point is located
by matching a placeholder comment or code pattern instead of a line number:

    :::>> file.before("index.js", match: "// Cleanup after server close")
    pool.end().then(() => { console.log('PG pool closed') })

    :::>> file.append("Gemfile", match: "gem 'rails'")
    gem 'pg'

`match:` raises if the target string is not unique in the file (safety check).
`match_first:` uses the first occurrence when duplicates are expected.

Also adds a new `file.before` command with the same kwargs.

Closes #121